### PR TITLE
Release/2.6.0

### DIFF
--- a/src/Framework/Application.php
+++ b/src/Framework/Application.php
@@ -43,7 +43,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
 	 *
 	 * @var string
 	 */
-	public const VERSION = '2.5.0';
+	public const VERSION = '2.6.0';
 
 	/**
 	 * The prefixes of absolute cache paths for use during normalization.

--- a/src/Framework/Application.php
+++ b/src/Framework/Application.php
@@ -11,6 +11,8 @@ use MVPS\Lumis\Framework\Contracts\Console\Kernel as ConsoleKernelContract;
 use MVPS\Lumis\Framework\Contracts\Framework\Application as ApplicationContract;
 use MVPS\Lumis\Framework\Contracts\Http\Kernel as HttpKernelContract;
 use MVPS\Lumis\Framework\Events\EventServiceProvider;
+use MVPS\Lumis\Framework\Http\Exceptions\HttpException;
+use MVPS\Lumis\Framework\Http\Exceptions\NotFoundException;
 use MVPS\Lumis\Framework\Http\Request;
 use MVPS\Lumis\Framework\Log\LogServiceProvider;
 use MVPS\Lumis\Framework\Providers\ServiceProvider;
@@ -225,6 +227,23 @@ class Application extends Container implements ApplicationContract, CachesConfig
 		$this->registerBaseBindings();
 		$this->registerBaseServiceProviders();
 		$this->registerCoreContainerAliases();
+	}
+
+	/**
+	 * Terminates execution and generates an HTTP response.
+	 *
+	 * Creates an appropriate HTTP exception based on the provided data.
+	 *
+	 * @throws \MVPS\Lumis\Framework\Http\Exceptions\HttpException
+	 * @throws \MVPS\Lumis\Framework\Http\Exceptions\NotFoundException
+	 */
+	public function abort(int $code, string $message = '', array $headers = []): never
+	{
+		if ($code === 404) {
+			throw new NotFoundException(message: $message, headers: $headers);
+		}
+
+		throw new HttpException(statusCode: $code, message: $message, headers: $headers);
 	}
 
 	/**

--- a/src/Framework/Application.php
+++ b/src/Framework/Application.php
@@ -910,6 +910,11 @@ class Application extends Container implements ApplicationContract, CachesConfig
 				\Illuminate\Contracts\Events\Dispatcher::class,
 			],
 			'files' => [\MVPS\Lumis\Framework\Filesystem\Filesystem::class],
+			'filesystem' => [
+				\MVPS\Lumis\Framework\Filesystem\FilesystemManager::class,
+				\MVPS\Lumis\Framework\Contracts\Filesystem\Factory::class,
+			],
+			'filesystem.disk' => [\MVPS\Lumis\Framework\Contracts\Filesystem\Filesystem::class],
 			'log' => [
 				\MVPS\Lumis\Framework\Log\LogService::class,
 				\Psr\Log\LoggerInterface::class,

--- a/src/Framework/Configuration/Middleware.php
+++ b/src/Framework/Configuration/Middleware.php
@@ -5,6 +5,7 @@ namespace MVPS\Lumis\Framework\Configuration;
 use Closure;
 use MVPS\Lumis\Framework\Http\Middleware\ConvertEmptyStringsToNull;
 use MVPS\Lumis\Framework\Http\Middleware\TrimStrings;
+use MVPS\Lumis\Framework\Http\Middleware\TrustHosts;
 use MVPS\Lumis\Framework\Http\Middleware\ValidatePostSize;
 use MVPS\Lumis\Framework\Support\Arr;
 
@@ -233,7 +234,7 @@ class Middleware
 	public function getGlobalMiddleware(): array
 	{
 		$middleware = $this->global ?: array_values(array_filter([
-			// $this->trustHosts ? TrustHosts::class : null,
+			$this->trustHosts ? TrustHosts::class : null,
 			// TrustProxies::class,
 			// HandleCors::class,
 			// PreventRequestsDuringMaintenance::class,
@@ -544,16 +545,14 @@ class Middleware
 
 	/**
 	 * Indicate that the trusted host middleware should be enabled.
-	 *
-	 * TODO: Implement this
 	 */
 	public function trustHosts(array|callable|null $at = null, bool $subdomains = true): static
 	{
-		// $this->trustHosts = true;
+		$this->trustHosts = true;
 
-		// if (! is_null($at)) {
-		// 	TrustHosts::at($at, $subdomains);
-		// }
+		if (! is_null($at)) {
+			TrustHosts::at($at, $subdomains);
+		}
 
 		return $this;
 	}

--- a/src/Framework/Configuration/Middleware.php
+++ b/src/Framework/Configuration/Middleware.php
@@ -6,7 +6,9 @@ use Closure;
 use MVPS\Lumis\Framework\Http\Middleware\ConvertEmptyStringsToNull;
 use MVPS\Lumis\Framework\Http\Middleware\TrimStrings;
 use MVPS\Lumis\Framework\Http\Middleware\TrustHosts;
+use MVPS\Lumis\Framework\Http\Middleware\TrustProxies;
 use MVPS\Lumis\Framework\Http\Middleware\ValidatePostSize;
+use MVPS\Lumis\Framework\Routing\Middleware\SubstituteBindings;
 use MVPS\Lumis\Framework\Support\Arr;
 
 class Middleware
@@ -235,7 +237,7 @@ class Middleware
 	{
 		$middleware = $this->global ?: array_values(array_filter([
 			$this->trustHosts ? TrustHosts::class : null,
-			// TrustProxies::class,
+			TrustProxies::class,
 			// HandleCors::class,
 			// PreventRequestsDuringMaintenance::class,
 			ValidatePostSize::class,
@@ -271,19 +273,19 @@ class Middleware
 	{
 		$middleware = [
 			'web' => array_values(array_filter([
-				// \Illuminate\Cookie\Middleware\EncryptCookies::class,
-				// \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
-				// \Illuminate\Session\Middleware\StartSession::class,
-				// \Illuminate\View\Middleware\ShareErrorsFromSession::class,
-				// \Illuminate\Foundation\Http\Middleware\ValidateCsrfToken::class,
-				\MVPS\Lumis\Framework\Routing\Middleware\SubstituteBindings::class,
+				// EncryptCookies::class,
+				// AddQueuedCookiesToResponse::class,
+				// StartSession::class,
+				// ShareErrorsFromSession::class,
+				// ValidateCsrfToken::class,
+				SubstituteBindings::class,
 				// $this->authenticatedSessions ? 'auth.session' : null,
 			])),
 
 			// TODO: Look at implementing this
 			// 'api' => array_values(array_filter([
 			// 	$this->apiLimiter ? 'throttle:'.$this->apiLimiter : null,
-			// 	\Illuminate\Routing\Middleware\SubstituteBindings::class,
+			// 	SubstituteBindings::class,
 			// ])),
 		];
 
@@ -559,18 +561,16 @@ class Middleware
 
 	/**
 	 * Configure the trusted proxies for the application.
-	 *
-	 * TODO: Implement this
 	 */
 	public function trustProxies(array|string|null $at = null, int|null $headers = null): static
 	{
-		// if (! is_null($at)) {
-		// 	TrustProxies::at($at);
-		// }
+		if (! is_null($at)) {
+			TrustProxies::at($at);
+		}
 
-		// if (! is_null($headers)) {
-		// 	TrustProxies::withHeaders($headers);
-		// }
+		if (! is_null($headers)) {
+			TrustProxies::withHeaders($headers);
+		}
 
 		return $this;
 	}

--- a/src/Framework/Configuration/Middleware.php
+++ b/src/Framework/Configuration/Middleware.php
@@ -4,6 +4,7 @@ namespace MVPS\Lumis\Framework\Configuration;
 
 use Closure;
 use MVPS\Lumis\Framework\Http\Middleware\ConvertEmptyStringsToNull;
+use MVPS\Lumis\Framework\Http\Middleware\TrimStrings;
 use MVPS\Lumis\Framework\Support\Arr;
 
 class Middleware
@@ -236,7 +237,7 @@ class Middleware
 			// HandleCors::class,
 			// PreventRequestsDuringMaintenance::class,
 			// ValidatePostSize::class,
-			// TrimStrings::class,
+			TrimStrings::class,
 			ConvertEmptyStringsToNull::class,
 		]));
 
@@ -526,16 +527,15 @@ class Middleware
 
 	/**
 	 * Configure the string trimming middleware.
-	 *
-	 * TODO: Implement this
 	 */
 	public function trimStrings(array $except = []): static
 	{
-		// [$skipWhen, $except] = collection($except)->partition(fn ($value) => $value instanceof Closure);
+		[$skipWhen, $except] = collection($except)
+			->partition(fn ($value) => $value instanceof Closure);
 
-		// $skipWhen->each(fn (Closure $callback) => TrimStrings::skipWhen($callback));
+		$skipWhen->each(fn (Closure $callback) => TrimStrings::skipWhen($callback));
 
-		// TrimStrings::except($except->all());
+		TrimStrings::except($except->all());
 
 		return $this;
 	}

--- a/src/Framework/Configuration/Middleware.php
+++ b/src/Framework/Configuration/Middleware.php
@@ -5,6 +5,7 @@ namespace MVPS\Lumis\Framework\Configuration;
 use Closure;
 use MVPS\Lumis\Framework\Http\Middleware\ConvertEmptyStringsToNull;
 use MVPS\Lumis\Framework\Http\Middleware\TrimStrings;
+use MVPS\Lumis\Framework\Http\Middleware\ValidatePostSize;
 use MVPS\Lumis\Framework\Support\Arr;
 
 class Middleware
@@ -236,14 +237,15 @@ class Middleware
 			// TrustProxies::class,
 			// HandleCors::class,
 			// PreventRequestsDuringMaintenance::class,
-			// ValidatePostSize::class,
+			ValidatePostSize::class,
 			TrimStrings::class,
 			ConvertEmptyStringsToNull::class,
 		]));
 
-		$middleware = array_map(function ($middleware) {
-			return $this->replacements[$middleware] ?? $middleware;
-		}, $middleware);
+		$middleware = array_map(
+			fn ($middleware) => $this->replacements[$middleware] ?? $middleware,
+			$middleware
+		);
 
 		return array_values(array_filter(array_diff(
 			array_unique(array_merge($this->prepends, $middleware, $this->appends)),

--- a/src/Framework/Configuration/Middleware.php
+++ b/src/Framework/Configuration/Middleware.php
@@ -4,6 +4,7 @@ namespace MVPS\Lumis\Framework\Configuration;
 
 use Closure;
 use MVPS\Lumis\Framework\Http\Middleware\ConvertEmptyStringsToNull;
+use MVPS\Lumis\Framework\Http\Middleware\HandlePrecognitiveRequests;
 use MVPS\Lumis\Framework\Http\Middleware\TrimStrings;
 use MVPS\Lumis\Framework\Http\Middleware\TrustHosts;
 use MVPS\Lumis\Framework\Http\Middleware\TrustProxies;
@@ -197,22 +198,22 @@ class Middleware
 	/**
 	 * Get the default middleware aliases.
 	 *
-	 * TODO: Implement this
+	 * TODO: Implement this list
 	 */
 	protected function defaultAliases(): array
 	{
 		$aliases = [
-			// 'auth' => \Illuminate\Auth\Middleware\Authenticate::class,
-			// 'auth.basic' => \Illuminate\Auth\Middleware\AuthenticateWithBasicAuth::class,
-			// 'auth.session' => \Illuminate\Session\Middleware\AuthenticateSession::class,
-			// 'cache.headers' => \Illuminate\Http\Middleware\SetCacheHeaders::class,
-			// 'can' => \Illuminate\Auth\Middleware\Authorize::class,
-			// 'guest' => \Illuminate\Auth\Middleware\RedirectIfAuthenticated::class,
-			// 'password.confirm' => \Illuminate\Auth\Middleware\RequirePassword::class,
-			// 'precognitive' => \Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests::class,
-			// 'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
-			// 'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
-			// 'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+			// 'auth' => Authenticate::class,
+			// 'auth.basic' => AuthenticateWithBasicAuth::class,
+			// 'auth.session' => AuthenticateSession::class,
+			// 'cache.headers' => SetCacheHeaders::class,
+			// 'can' => Authorize::class,
+			// 'guest' => RedirectIfAuthenticated::class,
+			// 'password.confirm' => RequirePassword::class,
+			'precognitive' => HandlePrecognitiveRequests::class,
+			// 'signed' => ValidateSignature::class,
+			// 'throttle' => ThrottleRequests::class,
+			// 'verified' => EnsureEmailIsVerified::class,
 		];
 
 		return $aliases;

--- a/src/Framework/Configuration/Middleware.php
+++ b/src/Framework/Configuration/Middleware.php
@@ -2,6 +2,8 @@
 
 namespace MVPS\Lumis\Framework\Configuration;
 
+use Closure;
+use MVPS\Lumis\Framework\Http\Middleware\ConvertEmptyStringsToNull;
 use MVPS\Lumis\Framework\Support\Arr;
 
 class Middleware
@@ -178,12 +180,11 @@ class Middleware
 
 	/**
 	 * Configure the empty string conversion middleware.
-	 *
-	 * TODO: Implement this
 	 */
 	public function convertEmptyStringsToNull(array $except = []): static
 	{
-		// collection($except)->each(fn (Closure $callback) => ConvertEmptyStringsToNull::skipWhen($callback));
+		collection($except)
+			->each(fn (Closure $callback) => ConvertEmptyStringsToNull::skipWhen($callback));
 
 		return $this;
 	}
@@ -226,22 +227,18 @@ class Middleware
 
 	/**
 	 * Get the global middleware.
-	 *
-	 * TODO: Implement array_values array
 	 */
 	public function getGlobalMiddleware(): array
 	{
-		// TODO: Remove this line when implementing
-		$middleware = $this->global;
-		// $middleware = $this->global ?: array_values(array_filter([
-		// 	$this->trustHosts ? \Illuminate\Http\Middleware\TrustHosts::class : null,
-		// 	\Illuminate\Http\Middleware\TrustProxies::class,
-		// 	\Illuminate\Http\Middleware\HandleCors::class,
-		// 	\Illuminate\Foundation\Http\Middleware\PreventRequestsDuringMaintenance::class,
-		// 	\Illuminate\Http\Middleware\ValidatePostSize::class,
-		// 	\Illuminate\Foundation\Http\Middleware\TrimStrings::class,
-		// 	\Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
-		// ]));
+		$middleware = $this->global ?: array_values(array_filter([
+			// $this->trustHosts ? TrustHosts::class : null,
+			// TrustProxies::class,
+			// HandleCors::class,
+			// PreventRequestsDuringMaintenance::class,
+			// ValidatePostSize::class,
+			// TrimStrings::class,
+			ConvertEmptyStringsToNull::class,
+		]));
 
 		$middleware = array_map(function ($middleware) {
 			return $this->replacements[$middleware] ?? $middleware;

--- a/src/Framework/Contracts/Filesystem/Factory.php
+++ b/src/Framework/Contracts/Filesystem/Factory.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Contracts\Filesystem;
+
+use Illuminate\Contracts\Filesystem\Factory as IlluminateFilesystemFactory;
+
+interface Factory extends IlluminateFilesystemFactory
+{
+}

--- a/src/Framework/Contracts/Filesystem/Filesystem.php
+++ b/src/Framework/Contracts/Filesystem/Filesystem.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Contracts\Filesystem;
+
+use Illuminate\Contracts\Filesystem\Filesystem as IlluminateFilesystem;
+
+interface Filesystem extends IlluminateFilesystem
+{
+}

--- a/src/Framework/Contracts/Routing/RouteCollection.php
+++ b/src/Framework/Contracts/Routing/RouteCollection.php
@@ -50,8 +50,8 @@ interface RouteCollection
 	/**
 	 * Find the first route matching a given request.
 	 *
-	 * @throws \MVPS\Lumis\Framework\Http\Exceptions\MethodNotAllowedHttpException
-	 * @throws \MVPS\Lumis\Framework\Http\Exceptions\NotFoundHttpException
+	 * @throws \MVPS\Lumis\Framework\Http\Exceptions\MethodNotAllowedException
+	 * @throws \MVPS\Lumis\Framework\Http\Exceptions\NotFoundException
 	 */
 	public function match(Request $request): Route;
 

--- a/src/Framework/Exceptions/Handler.php
+++ b/src/Framework/Exceptions/Handler.php
@@ -22,10 +22,10 @@ use MVPS\Lumis\Framework\Contracts\Http\Responsable;
 use MVPS\Lumis\Framework\Exceptions\Console\Handler as ConsoleHandler;
 use MVPS\Lumis\Framework\Exceptions\Console\Inspector;
 use MVPS\Lumis\Framework\Exceptions\Renderer\Renderer;
-use MVPS\Lumis\Framework\Http\Exceptions\BadRequestHttpException;
+use MVPS\Lumis\Framework\Http\Exceptions\BadRequestException;
 use MVPS\Lumis\Framework\Http\Exceptions\HttpException;
 use MVPS\Lumis\Framework\Http\Exceptions\HttpResponseException;
-use MVPS\Lumis\Framework\Http\Exceptions\NotFoundHttpException;
+use MVPS\Lumis\Framework\Http\Exceptions\NotFoundException;
 use MVPS\Lumis\Framework\Http\Request;
 use MVPS\Lumis\Framework\Http\Response;
 use MVPS\Lumis\Framework\Http\ResponseFactory;
@@ -456,10 +456,10 @@ class Handler implements ExceptionHandler
 	protected function prepareException(Throwable $e): Throwable
 	{
 		return match (true) {
-			$e instanceof BackedEnumCaseNotFoundException => new NotFoundHttpException($e->getMessage(), $e),
-			$e instanceof ModelNotFoundException => new NotFoundHttpException($e->getMessage(), $e),
-			$e instanceof RecordsNotFoundException => new NotFoundHttpException('Not found.', $e),
-			$e instanceof RequestExceptionInterface => new BadRequestHttpException('Bad request.', $e),
+			$e instanceof BackedEnumCaseNotFoundException => new NotFoundException($e->getMessage(), $e),
+			$e instanceof ModelNotFoundException => new NotFoundException($e->getMessage(), $e),
+			$e instanceof RecordsNotFoundException => new NotFoundException('Not found.', $e),
+			$e instanceof RequestExceptionInterface => new BadRequestException('Bad request.', $e),
 			default => $e,
 		};
 	}

--- a/src/Framework/Exceptions/Renderer/Exception.php
+++ b/src/Framework/Exceptions/Renderer/Exception.php
@@ -2,6 +2,7 @@
 
 namespace MVPS\Lumis\Framework\Exceptions\Renderer;
 
+use Closure;
 use Composer\Autoload\ClassLoader;
 use MVPS\Lumis\Framework\Bootstrap\HandleExceptions;
 use MVPS\Lumis\Framework\Collections\Collection;
@@ -25,6 +26,13 @@ class Exception
 	protected FlattenException $exception;
 
 	/**
+	 * The exception listener instance.
+	 *
+	 * @var \MVPS\Lumis\Framework\Exceptions\Renderer\Listener
+	 */
+	protected Listener $listener;
+
+	/**
 	 * The current request instance.
 	 *
 	 * @var \MVPS\Lumis\Framework\Http\Request
@@ -34,11 +42,39 @@ class Exception
 	/**
 	 * Creates a new exception renderer instance.
 	 */
-	public function __construct(FlattenException $exception, Request $request, string $basePath)
+	public function __construct(FlattenException $exception, Request $request, Listener $listener, string $basePath)
 	{
 		$this->exception = $exception;
 		$this->request = $request;
+		$this->listener = $listener;
 		$this->basePath = $basePath;
+	}
+
+	/**
+	 * Get the application's SQL queries.
+	 */
+	public function applicationQueries(): array
+	{
+		return array_map(
+			function (array $query) {
+				$sql = $query['sql'];
+
+				foreach ($query['bindings'] as $binding) {
+					$sql = match (gettype($binding)) {
+						'integer', 'double' => preg_replace('/\?/', $binding, $sql, 1),
+						'NULL' => preg_replace('/\?/', 'NULL', $sql, 1),
+						default => preg_replace('/\?/', "'$binding'", $sql, 1),
+					};
+				}
+
+				return [
+					'connectionName' => $query['connectionName'],
+					'time' => $query['time'],
+					'sql' => $sql,
+				];
+			},
+			$this->listener->queries()
+		);
 	}
 
 	/**
@@ -51,6 +87,10 @@ class Exception
 		return $route ? array_filter([
 			'controller' => $route->getActionName(),
 			'route name' => $route->getName() ?: null,
+			'middleware' => implode(', ', array_map(
+				fn ($middleware) => $middleware instanceof Closure ? 'Closure' : $middleware,
+				$route->gatherMiddleware()
+			)),
 		]) : [];
 	}
 
@@ -80,9 +120,10 @@ class Exception
 	 */
 	public function defaultFrame(): int
 	{
-		$key = array_search(false, array_map(function (Frame $frame) {
-			return $frame->isFromVendor();
-		}, $this->frames()->all()));
+		$key = array_search(false, array_map(
+			fn (Frame $frame) => $frame->isFromVendor(),
+			$this->frames()->all()
+		));
 
 		return $key === false ? 0 : $key;
 	}
@@ -106,12 +147,10 @@ class Exception
 			array_shift($trace);
 		}
 
-		return collection(
-			array_map(
-				fn (array $trace) => new Frame($this->exception, $classMap, $trace, $this->basePath),
-				$trace
-			)
-		);
+		return collection(array_map(
+			fn (array $trace) => new Frame($this->exception, $classMap, $trace, $this->basePath),
+			$trace
+		));
 	}
 
 	/**
@@ -151,9 +190,10 @@ class Exception
 	 */
 	public function requestHeaders(): array
 	{
-		return array_map(function (array $header) {
-			return implode(', ', $header);
-		}, $this->request()->getHeaders());
+		return array_map(
+			fn (array $header) => implode(', ', $header),
+			$this->request()->getHeaders()
+		);
 	}
 
 	/**

--- a/src/Framework/Exceptions/Renderer/Exception.php
+++ b/src/Framework/Exceptions/Renderer/Exception.php
@@ -174,7 +174,7 @@ class Exception
 	 */
 	public function requestBody(): string|null
 	{
-		$payload = $this->request()->input();
+		$payload = $this->request()->all();
 
 		if (empty($payload)) {
 			return null;

--- a/src/Framework/Exceptions/Renderer/Listener.php
+++ b/src/Framework/Exceptions/Renderer/Listener.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Exceptions\Renderer;
+
+use Illuminate\Database\Events\QueryExecuted;
+use MVPS\Lumis\Framework\Contracts\Events\Dispatcher;
+
+class Listener
+{
+	/**
+	 * The queries that have been executed.
+	 *
+	 * @var array<int, array{connectionName: string, time: float, sql: string, bindings: array}>
+	 */
+	protected array $queries = [];
+
+	/**
+	 * Listens for the query executed event.
+	 */
+	public function onQueryExecuted(QueryExecuted $event): void
+	{
+		if (count($this->queries) === 100) {
+			return;
+		}
+
+		$this->queries[] = [
+			'connectionName' => $event->connectionName,
+			'time' => $event->time,
+			'sql' => $event->sql,
+			'bindings' => $event->bindings,
+		];
+	}
+
+	/**
+	 * Returns the queries that have been executed.
+	 */
+	public function queries(): array
+	{
+		return $this->queries;
+	}
+
+	/**
+	 * Register the appropriate listeners on the given event dispatcher.
+	 */
+	public function registerListeners(Dispatcher $events): void
+	{
+		$events->listen(QueryExecuted::class, [$this, 'onQueryExecuted']);
+
+		// TODO: Implement with queue system
+		// $events->listen([JobProcessing::class, JobProcessed::class], function () {
+		// 	$this->queries = [];
+		// });
+	}
+}

--- a/src/Framework/Exceptions/Renderer/Renderer.php
+++ b/src/Framework/Exceptions/Renderer/Renderer.php
@@ -40,6 +40,13 @@ class Renderer
 	protected HtmlErrorRenderer $htmlErrorRenderer;
 
 	/**
+	 * The exception listener instance.
+	 *
+	 * @var \MVPS\Lumis\Framework\Exceptions\Renderer\Listener
+	 */
+	protected Listener $listener;
+
+	/**
 	 * The view factory instance.
 	 *
 	 * @var \MVPS\Lumis\Framework\Contracts\View\Factory
@@ -51,11 +58,13 @@ class Renderer
 	 */
 	public function __construct(
 		Factory $viewFactory,
+		Listener $listener,
 		HtmlErrorRenderer $htmlErrorRenderer,
 		BladeMapper $bladeMapper,
 		string $basePath
 	) {
 		$this->viewFactory = $viewFactory;
+		$this->listener = $listener;
 		$this->htmlErrorRenderer = $htmlErrorRenderer;
 		$this->bladeMapper = $bladeMapper;
 		$this->basePath = $basePath;
@@ -106,7 +115,7 @@ class Renderer
 
 		return $this->viewFactory->make(
 			'lumis-exceptions-renderer::show',
-			['exception' => new Exception($flattenException, $request, $this->basePath)]
+			['exception' => new Exception($flattenException, $request, $this->listener, $this->basePath)]
 		)
 		->render();
 	}

--- a/src/Framework/Filesystem/FilesystemManager.php
+++ b/src/Framework/Filesystem/FilesystemManager.php
@@ -1,0 +1,303 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Filesystem;
+
+use Closure;
+use InvalidArgumentException;
+use MVPS\Lumis\Framework\Contracts\Filesystem\Factory as FactoryContract;
+use MVPS\Lumis\Framework\Contracts\Filesystem\Filesystem;
+use MVPS\Lumis\Framework\Contracts\Framework\Application;
+
+class FilesystemManager implements FactoryContract
+{
+	/**
+	 * The application instance.
+	 *
+	 * @var \MVPS\Lumis\Framework\Contracts\Framework\Application
+	 */
+	protected Application $app;
+
+	/**
+	 * The registered custom driver creators.
+	 *
+	 * @var array
+	 */
+	protected array $customCreators = [];
+
+	/**
+	 * The array of resolved filesystem drivers.
+	 *
+	 * @var array
+	 */
+	protected array $disks = [];
+
+	/**
+	 * Create a new filesystem manager instance.
+	 */
+	public function __construct(Application $app)
+	{
+		$this->app = $app;
+	}
+
+	/**
+	 * Build an on-demand disk.
+	 */
+	public function build(string|array $config): Filesystem
+	{
+		return $this->resolve('ondemand', is_array($config) ? $config : [
+			'driver' => 'local',
+			'root' => $config,
+		]);
+	}
+
+	/**
+	 * Call a custom driver creator.
+	 */
+	protected function callCustomCreator(array $config): Filesystem
+	{
+		return $this->customCreators[$config['driver']]($this->app, $config);
+	}
+
+	/**
+	 * Create a Flysystem instance with the given adapter.
+	 * TODO: Implement this
+	 * @param  \League\Flysystem\FilesystemAdapter  $adapter
+	 * @param  array  $config
+	 * @return \League\Flysystem\FilesystemOperator
+	 */
+	// protected function createFlysystem(FlysystemAdapter $adapter, array $config)
+	// {
+	// 	if ($config['read-only'] ?? false === true) {
+	// 		$adapter = new ReadOnlyFilesystemAdapter($adapter);
+	// 	}
+
+	// 	if (! empty($config['prefix'])) {
+	// 		$adapter = new PathPrefixedAdapter($adapter, $config['prefix']);
+	// 	}
+
+	// 	return new Flysystem($adapter, Arr::only($config, [
+	// 		'directory_visibility',
+	// 		'disable_asserts',
+	// 		'retain_visibility',
+	// 		'temporary_url',
+	// 		'url',
+	// 		'visibility',
+	// 	]));
+	// }
+
+	/**
+	 * Create an instance of the ftp driver.
+	 * TODO: Implement this
+	 * @param  array  $config
+	 * @return \Illuminate\Contracts\Filesystem\Filesystem
+	 */
+	// public function createFtpDriver(array $config)
+	// {
+	// 	if (! isset($config['root'])) {
+	// 		$config['root'] = '';
+	// 	}
+
+	// 	$adapter = new FtpAdapter(FtpConnectionOptions::fromArray($config));
+
+	// 	return new FilesystemAdapter($this->createFlysystem($adapter, $config), $adapter, $config);
+	// }
+
+	/**
+	 * Create an instance of the local driver.
+	 * TODO: Implement this
+	 *
+	 * @param  array  $config
+	 * @return \Illuminate\Contracts\Filesystem\Filesystem
+	 */
+	// public function createLocalDriver(array $config): Filesystem
+	// {
+	// 	$visibility = PortableVisibilityConverter::fromArray(
+	// 		$config['permissions'] ?? [],
+	// 		$config['directory_visibility'] ?? $config['visibility'] ?? Visibility::PRIVATE
+	// 	);
+
+	// 	$links = ($config['links'] ?? null) === 'skip'
+	// 		? LocalAdapter::SKIP_LINKS
+	// 		: LocalAdapter::DISALLOW_LINKS;
+
+	// 	$adapter = new LocalAdapter(
+	// 		$config['root'], $visibility, $config['lock'] ?? LOCK_EX, $links
+	// 	);
+
+	// 	return new FilesystemAdapter($this->createFlysystem($adapter, $config), $adapter, $config);
+	// }
+
+	/**
+	 * Create a scoped driver.
+	 */
+	public function createScopedDriver(array $config): Filesystem
+	{
+		if (empty($config['disk'])) {
+			throw new InvalidArgumentException('Scoped disk is missing "disk" configuration option.');
+		} elseif (empty($config['prefix'])) {
+			throw new InvalidArgumentException('Scoped disk is missing "prefix" configuration option.');
+		}
+
+		return $this->build(tap(
+			is_string($config['disk']) ? $this->getConfig($config['disk']) : $config['disk'],
+			function (&$parent) use ($config) {
+				$parent['prefix'] = $config['prefix'];
+
+				if (isset($config['visibility'])) {
+					$parent['visibility'] = $config['visibility'];
+				}
+			}
+		));
+	}
+
+	/**
+	 * Create an instance of the sftp driver.
+	 * TODO: Implement this
+	 * @param  array  $config
+	 * @return \Illuminate\Contracts\Filesystem\Filesystem
+	 */
+	// public function createSftpDriver(array $config)
+	// {
+	// 	$provider = SftpConnectionProvider::fromArray($config);
+
+	// 	$root = $config['root'] ?? '';
+
+	// 	$visibility = PortableVisibilityConverter::fromArray(
+	// 		$config['permissions'] ?? []
+	// 	);
+
+	// 	$adapter = new SftpAdapter($provider, $root, $visibility);
+
+	// 	return new FilesystemAdapter($this->createFlysystem($adapter, $config), $adapter, $config);
+	// }
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function disk($name = null): Filesystem
+	{
+		$name = $name ?: $this->getDefaultDriver();
+
+		return $this->disks[$name] = $this->get($name);
+	}
+
+	/**
+	 * Get a filesystem instance.
+	 */
+	public function drive(string|null $name = null): Filesystem
+	{
+		return $this->disk($name);
+	}
+
+	/**
+	 * Register a custom driver creator Closure.
+	 */
+	public function extend(string $driver, Closure $callback): static
+	{
+		$this->customCreators[$driver] = $callback;
+
+		return $this;
+	}
+
+	/**
+	 * Unset the given disk instances.
+	 */
+	public function forgetDisk(array|string $disk): static
+	{
+		foreach ((array) $disk as $diskName) {
+			unset($this->disks[$diskName]);
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Attempt to get the disk from the local cache.
+	 */
+	protected function get(string $name): Filesystem
+	{
+		return $this->disks[$name] ?? $this->resolve($name);
+	}
+
+	/**
+	 * Get the filesystem connection configuration.
+	 */
+	protected function getConfig(string $name): array
+	{
+		return $this->app['config']["filesystems.disks.{$name}"] ?: [];
+	}
+
+	/**
+	 * Get the default driver name.
+	 */
+	public function getDefaultDriver(): string
+	{
+		return $this->app['config']['filesystems.default'];
+	}
+
+	/**
+	 * Disconnect the given disk and remove from local cache.
+	 */
+	public function purge(string|null $name = null): void
+	{
+		$name ??= $this->getDefaultDriver();
+
+		unset($this->disks[$name]);
+	}
+
+	/**
+	 * Resolve the given disk.
+	 *
+	 * @throws \InvalidArgumentException
+	 */
+	protected function resolve(string $name, array|null $config = null): Filesystem
+	{
+		$config ??= $this->getConfig($name);
+
+		if (empty($config['driver'])) {
+			throw new InvalidArgumentException("Disk [{$name}] does not have a configured driver.");
+		}
+
+		$name = $config['driver'];
+
+		if (isset($this->customCreators[$name])) {
+			return $this->callCustomCreator($config);
+		}
+
+		$driverMethod = 'create' . ucfirst($name) . 'Driver';
+
+		if (! method_exists($this, $driverMethod)) {
+			throw new InvalidArgumentException("Driver [{$name}] is not supported.");
+		}
+
+		return $this->{$driverMethod}($config);
+	}
+
+	/**
+	 * Set the given disk instance.
+	 */
+	public function set(string $name, mixed $disk): static
+	{
+		$this->disks[$name] = $disk;
+
+		return $this;
+	}
+
+	/**
+	 * Set the application instance used by the manager.
+	 */
+	public function setApplication(Application $app)
+	{
+		$this->app = $app;
+
+		return $this;
+	}
+
+	/**
+	 * Dynamically call the default driver instance.
+	 */
+	public function __call(string $method, array $parameters): mixed
+	{
+		return $this->disk()->$method(...$parameters);
+	}
+}

--- a/src/Framework/Filesystem/FilesystemServiceProvider.php
+++ b/src/Framework/Filesystem/FilesystemServiceProvider.php
@@ -7,11 +7,43 @@ use MVPS\Lumis\Framework\Providers\ServiceProvider;
 class FilesystemServiceProvider extends ServiceProvider
 {
 	/**
+	 * Get the default file driver.
+	 */
+	protected function getDefaultDriver(): string
+	{
+		return $this->app['config']['filesystems.default'];
+	}
+
+	/**
 	 * Register the filesystem service provider.
 	 */
 	public function register(): void
 	{
 		$this->registerNativeFilesystem();
+
+		$this->registerDrivers();
+	}
+
+	/**
+	 * Register the driver based filesystem.
+	 */
+	protected function registerDrivers(): void
+	{
+		$this->registerManager();
+
+		$this->app->singleton('filesystem.disk', function ($app) {
+			return $app['filesystem']->disk($this->getDefaultDriver());
+		});
+	}
+
+	/**
+	 * Register the filesystem manager.
+	 */
+	protected function registerManager(): void
+	{
+		$this->app->singleton('filesystem', function ($app) {
+			return new FilesystemManager($app);
+		});
 	}
 
 	/**

--- a/src/Framework/Http/Exceptions/AccessDeniedException.php
+++ b/src/Framework/Http/Exceptions/AccessDeniedException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Http\Exceptions;
+
+use Throwable;
+
+class AccessDeniedException extends HttpException
+{
+	/**
+	 * Create a new access denied HTTP exception instance.
+	 */
+	public function __construct(
+		string $message = '',
+		Throwable|null $previous = null,
+		int $code = 0,
+		array $headers = []
+	) {
+		parent::__construct(403, $message, $previous, $headers, $code);
+	}
+}

--- a/src/Framework/Http/Exceptions/AccessDeniedException.php
+++ b/src/Framework/Http/Exceptions/AccessDeniedException.php
@@ -7,7 +7,7 @@ use Throwable;
 class AccessDeniedException extends HttpException
 {
 	/**
-	 * Create a new access denied HTTP exception instance.
+	 * Create a new "Access Denied" HTTP exception instance.
 	 */
 	public function __construct(
 		string $message = '',

--- a/src/Framework/Http/Exceptions/BadRequestException.php
+++ b/src/Framework/Http/Exceptions/BadRequestException.php
@@ -4,10 +4,10 @@ namespace MVPS\Lumis\Framework\Http\Exceptions;
 
 use Throwable;
 
-class NotFoundHttpException extends HttpException
+class BadRequestException extends HttpException
 {
 	/**
-	 * Create a new not found HTTP exception instance.
+	 * Create a new bad request HTTP exception instance.
 	 */
 	public function __construct(
 		string $message = '',
@@ -15,6 +15,6 @@ class NotFoundHttpException extends HttpException
 		int $code = 0,
 		array $headers = []
 	) {
-		parent::__construct(404, $message, $previous, $headers, $code);
+		parent::__construct(400, $message, $previous, $headers, $code);
 	}
 }

--- a/src/Framework/Http/Exceptions/BadRequestException.php
+++ b/src/Framework/Http/Exceptions/BadRequestException.php
@@ -7,7 +7,7 @@ use Throwable;
 class BadRequestException extends HttpException
 {
 	/**
-	 * Create a new bad request HTTP exception instance.
+	 * Create a new "Bad Request" HTTP exception instance.
 	 */
 	public function __construct(
 		string $message = '',

--- a/src/Framework/Http/Exceptions/ConflictException.php
+++ b/src/Framework/Http/Exceptions/ConflictException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Http\Exceptions;
+
+use Throwable;
+
+class ConflictException extends HttpException
+{
+	/**
+	 * Create a new "Conflict" HTTP exception instance.
+	 */
+	public function __construct(
+		string $message = '',
+		Throwable|null $previous = null,
+		int $code = 0,
+		array $headers = []
+	) {
+		parent::__construct(409, $message, $previous, $headers, $code);
+	}
+}

--- a/src/Framework/Http/Exceptions/ContentTooLargeException.php
+++ b/src/Framework/Http/Exceptions/ContentTooLargeException.php
@@ -4,16 +4,16 @@ namespace MVPS\Lumis\Framework\Http\Exceptions;
 
 use Throwable;
 
-class PostTooLargeException extends HttpException
+class ContentTooLargeException extends HttpException
 {
 	/**
-	 * Create a new "post too large" HTTP exception instance.
+	 * Create a new "Content Too Large" HTTP exception instance.
 	 */
 	public function __construct(
 		string $message = '',
 		Throwable|null $previous = null,
-		array $headers = [],
-		int $code = 0
+		int $code = 0,
+		array $headers = []
 	) {
 		parent::__construct(413, $message, $previous, $headers, $code);
 	}

--- a/src/Framework/Http/Exceptions/GoneException.php
+++ b/src/Framework/Http/Exceptions/GoneException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Http\Exceptions;
+
+use Throwable;
+
+class GoneException extends HttpException
+{
+	/**
+	 * Create a new "Gone" HTTP exception instance.
+	 */
+	public function __construct(
+		string $message = '',
+		Throwable|null $previous = null,
+		int $code = 0,
+		array $headers = []
+	) {
+		parent::__construct(410, $message, $previous, $headers, $code);
+	}
+}

--- a/src/Framework/Http/Exceptions/HttpException.php
+++ b/src/Framework/Http/Exceptions/HttpException.php
@@ -35,6 +35,39 @@ class HttpException extends RuntimeException implements HttpExceptionContract
 	}
 
 	/**
+	 * Creates an appropriate HTTP exception based on the given status code.
+	 *
+	 * Maps the provided status code to a specific HTTP exception subclass.
+	 * If no matching subclass is found, a generic HTTP exception is created.
+	 */
+	public static function fromStatusCode(
+		int $statusCode,
+		string $message = '',
+		Throwable|null $previous = null,
+		array $headers = [],
+		int $code = 0
+	): static {
+		return match ($statusCode) {
+			400 => new BadRequestException($message, $previous, $code, $headers),
+			403 => new AccessDeniedException($message, $previous, $code, $headers),
+			404 => new NotFoundException($message, $previous, $code, $headers),
+			406 => new NotAcceptableException($message, $previous, $code, $headers),
+			409 => new ConflictException($message, $previous, $code, $headers),
+			410 => new GoneException($message, $previous, $code, $headers),
+			411 => new LengthRequiredException($message, $previous, $code, $headers),
+			412 => new PreconditionFailedException($message, $previous, $code, $headers),
+			413 => new ContentTooLargeException($message, $previous, $code, $headers),
+			415 => new UnsupportedMediaTypeException($message, $previous, $code, $headers),
+			422 => new UnprocessableEntityException($message, $previous, $code, $headers),
+			423 => new LockedException($message, $previous, $code, $headers),
+			428 => new PreconditionRequiredException($message, $previous, $code, $headers),
+			429 => new TooManyRequestsException(null, $message, $previous, $code, $headers),
+			503 => new ServiceUnavailableException(null, $message, $previous, $code, $headers),
+			default => new static($statusCode, $message, $previous, $headers, $code),
+		};
+	}
+
+	/**
 	 * Get the HTTP headers.
 	 */
 	public function getHeaders(): array

--- a/src/Framework/Http/Exceptions/LengthRequiredException.php
+++ b/src/Framework/Http/Exceptions/LengthRequiredException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Http\Exceptions;
+
+use Throwable;
+
+class LengthRequiredException extends HttpException
+{
+	/**
+	 * Create a new "Length Required" HTTP exception instance.
+	 */
+	public function __construct(
+		string $message = '',
+		Throwable|null $previous = null,
+		int $code = 0,
+		array $headers = []
+	) {
+		parent::__construct(411, $message, $previous, $headers, $code);
+	}
+}

--- a/src/Framework/Http/Exceptions/LockedException.php
+++ b/src/Framework/Http/Exceptions/LockedException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Http\Exceptions;
+
+use Throwable;
+
+class LockedException extends HttpException
+{
+	/**
+	 * Create a new "Locked" HTTP exception instance.
+	 */
+	public function __construct(
+		string $message = '',
+		Throwable|null $previous = null,
+		int $code = 0,
+		array $headers = []
+	) {
+		parent::__construct(423, $message, $previous, $headers, $code);
+	}
+}

--- a/src/Framework/Http/Exceptions/MethodNotAllowedException.php
+++ b/src/Framework/Http/Exceptions/MethodNotAllowedException.php
@@ -4,7 +4,7 @@ namespace MVPS\Lumis\Framework\Http\Exceptions;
 
 use Throwable;
 
-class MethodNotAllowedHttpException extends HttpException
+class MethodNotAllowedException extends HttpException
 {
 	/**
 	 * Create a method not allowed HTTP exception instance.

--- a/src/Framework/Http/Exceptions/NotAcceptableException.php
+++ b/src/Framework/Http/Exceptions/NotAcceptableException.php
@@ -7,7 +7,7 @@ use Throwable;
 class NotAcceptableException extends HttpException
 {
 	/**
-	 * Create a new access denied HTTP exception instance.
+	 * Create a new not acceptable HTTP exception instance.
 	 */
 	public function __construct(
 		string $message = '',

--- a/src/Framework/Http/Exceptions/NotAcceptableException.php
+++ b/src/Framework/Http/Exceptions/NotAcceptableException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Http\Exceptions;
+
+use Throwable;
+
+class NotAcceptableException extends HttpException
+{
+	/**
+	 * Create a new access denied HTTP exception instance.
+	 */
+	public function __construct(
+		string $message = '',
+		Throwable|null $previous = null,
+		int $code = 0,
+		array $headers = []
+	) {
+		parent::__construct(403, $message, $previous, $headers, $code);
+	}
+}

--- a/src/Framework/Http/Exceptions/NotFoundException.php
+++ b/src/Framework/Http/Exceptions/NotFoundException.php
@@ -4,10 +4,10 @@ namespace MVPS\Lumis\Framework\Http\Exceptions;
 
 use Throwable;
 
-class BadRequestHttpException extends HttpException
+class NotFoundException extends HttpException
 {
 	/**
-	 * Create a new bad request HTTP exception instance.
+	 * Create a new not found HTTP exception instance.
 	 */
 	public function __construct(
 		string $message = '',
@@ -15,6 +15,6 @@ class BadRequestHttpException extends HttpException
 		int $code = 0,
 		array $headers = []
 	) {
-		parent::__construct(400, $message, $previous, $headers, $code);
+		parent::__construct(404, $message, $previous, $headers, $code);
 	}
 }

--- a/src/Framework/Http/Exceptions/PostTooLargeException.php
+++ b/src/Framework/Http/Exceptions/PostTooLargeException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Http\Exceptions;
+
+use Throwable;
+
+class PostTooLargeException extends HttpException
+{
+	/**
+	 * Create a new "post too large" exception instance.
+	 */
+	public function __construct(
+		string $message = '',
+		Throwable|null $previous = null,
+		array $headers = [],
+		int $code = 0
+	) {
+		parent::__construct(413, $message, $previous, $headers, $code);
+	}
+}

--- a/src/Framework/Http/Exceptions/PostTooLargeException.php
+++ b/src/Framework/Http/Exceptions/PostTooLargeException.php
@@ -7,7 +7,7 @@ use Throwable;
 class PostTooLargeException extends HttpException
 {
 	/**
-	 * Create a new "post too large" exception instance.
+	 * Create a new "post too large" HTTP exception instance.
 	 */
 	public function __construct(
 		string $message = '',

--- a/src/Framework/Http/Exceptions/PreconditionFailedException.php
+++ b/src/Framework/Http/Exceptions/PreconditionFailedException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Http\Exceptions;
+
+use Throwable;
+
+class PreconditionFailedException extends HttpException
+{
+	/**
+	 * Create a new "Precondition Failed" HTTP exception instance.
+	 */
+	public function __construct(
+		string $message = '',
+		Throwable|null $previous = null,
+		int $code = 0,
+		array $headers = []
+	) {
+		parent::__construct(412, $message, $previous, $headers, $code);
+	}
+}

--- a/src/Framework/Http/Exceptions/PreconditionRequiredException.php
+++ b/src/Framework/Http/Exceptions/PreconditionRequiredException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Http\Exceptions;
+
+use Throwable;
+
+class PreconditionRequiredException extends HttpException
+{
+	/**
+	 * Create a new "Precondition Required" HTTP exception instance.
+	 */
+	public function __construct(
+		string $message = '',
+		Throwable|null $previous = null,
+		int $code = 0,
+		array $headers = []
+	) {
+		parent::__construct(428, $message, $previous, $headers, $code);
+	}
+}

--- a/src/Framework/Http/Exceptions/ServiceUnavailableException.php
+++ b/src/Framework/Http/Exceptions/ServiceUnavailableException.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Http\Exceptions;
+
+use Throwable;
+
+class ServiceUnavailableException extends HttpException
+{
+	/**
+	 * Create a new "Service Unavailable" HTTP exception instance.
+	 */
+	public function __construct(
+		int|string|null $retryAfter = null,
+		string $message = '',
+		Throwable|null $previous = null,
+		int $code = 0,
+		array $headers = []
+	) {
+		if ($retryAfter) {
+			$headers['Retry-After'] = $retryAfter;
+		}
+
+		parent::__construct(503, $message, $previous, $headers, $code);
+	}
+}

--- a/src/Framework/Http/Exceptions/TooManyRequestsException.php
+++ b/src/Framework/Http/Exceptions/TooManyRequestsException.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Http\Exceptions;
+
+use Throwable;
+
+class TooManyRequestsException extends HttpException
+{
+	/**
+	 * Create a new "Too Many Requests" HTTP exception instance.
+	 */
+	public function __construct(
+		int|string|null $retryAfter = null,
+		string $message = '',
+		Throwable|null $previous = null,
+		int $code = 0,
+		array $headers = []
+	) {
+		if ($retryAfter) {
+			$headers['Retry-After'] = $retryAfter;
+		}
+
+		parent::__construct(429, $message, $previous, $headers, $code);
+	}
+}

--- a/src/Framework/Http/Exceptions/UnprocessableEntityException.php
+++ b/src/Framework/Http/Exceptions/UnprocessableEntityException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Http\Exceptions;
+
+use Throwable;
+
+class UnprocessableEntityException extends HttpException
+{
+	/**
+	 * Create a new "Unsupported Media Type" HTTP exception instance.
+	 */
+	public function __construct(
+		string $message = '',
+		Throwable|null $previous = null,
+		int $code = 0,
+		array $headers = []
+	) {
+		parent::__construct(422, $message, $previous, $headers, $code);
+	}
+}

--- a/src/Framework/Http/Exceptions/UnsupportedMediaTypeException.php
+++ b/src/Framework/Http/Exceptions/UnsupportedMediaTypeException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Http\Exceptions;
+
+use Throwable;
+
+class UnsupportedMediaTypeException extends HttpException
+{
+	/**
+	 * Create a new "Unsupported Media Type" HTTP exception instance.
+	 */
+	public function __construct(
+		string $message = '',
+		Throwable|null $previous = null,
+		int $code = 0,
+		array $headers = []
+	) {
+		parent::__construct(415, $message, $previous, $headers, $code);
+	}
+}

--- a/src/Framework/Http/Kernel.php
+++ b/src/Framework/Http/Kernel.php
@@ -17,6 +17,7 @@ use MVPS\Lumis\Framework\Contracts\Exceptions\ExceptionHandler;
 use MVPS\Lumis\Framework\Contracts\Framework\Application;
 use MVPS\Lumis\Framework\Contracts\Http\Kernel as KernelContract;
 use MVPS\Lumis\Framework\Http\Events\RequestHandled;
+use MVPS\Lumis\Framework\Http\Middleware\HandlePrecognitiveRequests;
 use MVPS\Lumis\Framework\Http\Response;
 use MVPS\Lumis\Framework\Routing\Middleware\SubstituteBindings;
 use MVPS\Lumis\Framework\Routing\Pipeline;
@@ -73,10 +74,10 @@ class Kernel implements KernelContract
 	 *
 	 * Forces non-global middleware to always be in the given order.
 	 *
-	 * @var string[]
+	 * @var array<string>
 	 */
 	protected array $middlewarePriority = [
-		// HandlePrecognitiveRequests::class,
+		HandlePrecognitiveRequests::class,
 		// EncryptCookies::class,
 		// AddQueuedCookiesToResponse::class,
 		// StartSession::class,

--- a/src/Framework/Http/Kernel.php
+++ b/src/Framework/Http/Kernel.php
@@ -83,7 +83,6 @@ class Kernel implements KernelContract
 		// ShareErrorsFromSession::class,
 		// AuthenticatesRequests::class,
 		// ThrottleRequests::class,
-		// ThrottleRequestsWithRedis::class,
 		// AuthenticatesSessions::class,
 		SubstituteBindings::class,
 		// Authorize::class,

--- a/src/Framework/Http/Middleware/ConvertEmptyStringsToNull.php
+++ b/src/Framework/Http/Middleware/ConvertEmptyStringsToNull.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Http\Middleware;
+
+use Closure;
+use MVPS\Lumis\Framework\Http\Request;
+
+class ConvertEmptyStringsToNull extends TransformsRequest
+{
+	/**
+	 * All of the registered skip callbacks.
+	 *
+	 * @var array
+	 */
+	protected static array $skipCallbacks = [];
+
+	/**
+	 * Flush the middleware's global state.
+	 */
+	public static function flushState(): void
+	{
+		static::$skipCallbacks = [];
+	}
+
+	/**
+	 * Handle an incoming request.
+	 */
+	public function handle(Request $request, Closure $next): mixed
+	{
+		foreach (static::$skipCallbacks as $callback) {
+			if ($callback($request)) {
+				return $next($request);
+			}
+		}
+
+		return parent::handle($request, $next);
+	}
+
+	/**
+	 * Register a callback that instructs the middleware to be skipped.
+	 */
+	public static function skipWhen(Closure $callback): void
+	{
+		static::$skipCallbacks[] = $callback;
+	}
+
+	/**
+	 * Transform the given value.
+	 */
+	protected function transform(string $key, mixed $value): mixed
+	{
+		return $value === '' ? null : $value;
+	}
+}

--- a/src/Framework/Http/Middleware/HandlePrecognitiveRequests.php
+++ b/src/Framework/Http/Middleware/HandlePrecognitiveRequests.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Http\Middleware;
+
+use Closure;
+use MVPS\Lumis\Framework\Contracts\Container\Container;
+use MVPS\Lumis\Framework\Contracts\Routing\CallableDispatcher;
+use MVPS\Lumis\Framework\Contracts\Routing\ControllerDispatcher;
+use MVPS\Lumis\Framework\Http\Request;
+use MVPS\Lumis\Framework\Http\Response;
+use MVPS\Lumis\Framework\Routing\PrecognitionCallableDispatcher;
+use MVPS\Lumis\Framework\Routing\PrecognitionControllerDispatcher;
+
+class HandlePrecognitiveRequests
+{
+	/**
+	 * The container instance.
+	 *
+	 * @var \MVPS\Lumis\Framework\Contracts\Container\Container
+	 */
+	protected Container $container;
+
+	/**
+	 * Create a new handle precognitive requests HTTP middleware instance.
+	 */
+	public function __construct(Container $container)
+	{
+		$this->container = $container;
+	}
+
+	/**
+	 * Append the appropriate "Vary" header to the given response.
+	 */
+	protected function appendVaryHeader(Request $request, Response $response): Response
+	{
+		return tap(
+			$response,
+			fn () => $response->headerBag->set(
+				'Vary',
+				implode(', ', array_filter([$response->headerBag->get('Vary'), 'Precognition']))
+			)
+		);
+	}
+
+	/**
+	 * Handle an incoming request.
+	 */
+	public function handle(Request $request, Closure $next): Response
+	{
+		if (! $request->isAttemptingPrecognition()) {
+			return $this->appendVaryHeader($request, $next($request));
+		}
+
+		$this->prepareForPrecognition($request);
+
+		return tap($next($request), function ($response) use ($request) {
+			$response->headerBag->set('Precognition', 'true');
+
+			$this->appendVaryHeader($request, $response);
+		});
+	}
+
+	/**
+	 * Prepare to handle a precognitive request.
+	 */
+	protected function prepareForPrecognition(Request $request): void
+	{
+		$request->attributeBag->set('precognitive', true);
+
+		$this->container->bind(CallableDispatcher::class, fn ($app) => new PrecognitionCallableDispatcher($app));
+		$this->container->bind(ControllerDispatcher::class, fn ($app) => new PrecognitionControllerDispatcher($app));
+	}
+}

--- a/src/Framework/Http/Middleware/TransformsRequest.php
+++ b/src/Framework/Http/Middleware/TransformsRequest.php
@@ -13,12 +13,12 @@ class TransformsRequest
 	 */
 	protected function clean(Request $request): void
 	{
-		$this->cleanParameterBag($request->query);
+		$this->cleanParameterBag($request->queryBag);
 
 		if ($request->isJson()) {
 			$this->cleanParameterBag($request->json());
-		} elseif ($request->request !== $request->query) {
-			$this->cleanParameterBag($request->request);
+		} elseif ($request->requestBag !== $request->queryBag) {
+			$this->cleanParameterBag($request->requestBag);
 		}
 	}
 

--- a/src/Framework/Http/Middleware/TransformsRequest.php
+++ b/src/Framework/Http/Middleware/TransformsRequest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Http\Middleware;
+
+use Closure;
+use MVPS\Lumis\Framework\Http\Request;
+use Symfony\Component\HttpFoundation\ParameterBag;
+
+class TransformsRequest
+{
+	/**
+	 * Clean the request's data.
+	 */
+	protected function clean(Request $request): void
+	{
+		$this->cleanParameterBag($request->query);
+
+		if ($request->isJson()) {
+			$this->cleanParameterBag($request->json());
+		} elseif ($request->request !== $request->query) {
+			$this->cleanParameterBag($request->request);
+		}
+	}
+
+	/**
+	 * Clean the data in the given array.
+	 */
+	protected function cleanArray(array $data, string $keyPrefix = ''): array
+	{
+		foreach ($data as $key => $value) {
+			$data[$key] = $this->cleanValue($keyPrefix . $key, $value);
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Clean the data in the parameter bag.
+	 */
+	protected function cleanParameterBag(ParameterBag $bag): void
+	{
+		$bag->replace($this->cleanArray($bag->all()));
+	}
+
+	/**
+	 * Clean the given value.
+	 */
+	protected function cleanValue(string $key, mixed $value): mixed
+	{
+		if (is_array($value)) {
+			return $this->cleanArray($value, $key . '.');
+		}
+
+		return $this->transform($key, $value);
+	}
+
+	/**
+	 * Handle an incoming request.
+	 */
+	public function handle(Request $request, Closure $next): mixed
+	{
+		$this->clean($request);
+
+		return $next($request);
+	}
+
+	/**
+	 * Transform the given value.
+	 */
+	protected function transform(string $key, mixed $value): mixed
+	{
+		return $value;
+	}
+}

--- a/src/Framework/Http/Middleware/TrimStrings.php
+++ b/src/Framework/Http/Middleware/TrimStrings.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Http\Middleware;
+
+use Closure;
+use MVPS\Lumis\Framework\Http\Request;
+use MVPS\Lumis\Framework\Support\Arr;
+use MVPS\Lumis\Framework\Support\Str;
+
+class TrimStrings extends TransformsRequest
+{
+	/**
+	 * The attributes that should not be trimmed.
+	 *
+	 * @var array<int, string>
+	 */
+	protected array $except = [
+		'current_password',
+		'password',
+		'password_confirmation',
+	];
+
+	/**
+	 * The globally ignored attributes that should not be trimmed.
+	 *
+	 * @var array
+	 */
+	protected static array $neverTrim = [];
+
+	/**
+	 * All of the registered skip callbacks.
+	 *
+	 * @var array
+	 */
+	protected static array $skipCallbacks = [];
+
+	/**
+	 * Indicate that the given attributes should never be trimmed.
+	 */
+	public static function except(array|string $attributes): void
+	{
+		static::$neverTrim = array_values(array_unique(
+			array_merge(static::$neverTrim, Arr::wrap($attributes))
+		));
+	}
+
+	/**
+	 * Flush the middleware's global state.
+	 */
+	public static function flushState(): void
+	{
+		static::$neverTrim = [];
+
+		static::$skipCallbacks = [];
+	}
+
+	/**
+	 * Handle an incoming request.
+	 */
+	public function handle(Request $request, Closure $next): mixed
+	{
+		foreach (static::$skipCallbacks as $callback) {
+			if ($callback($request)) {
+				return $next($request);
+			}
+		}
+
+		return parent::handle($request, $next);
+	}
+
+	/**
+	 * Determine if the given key should be skipped.
+	 */
+	protected function shouldSkip(string $key, array $except): bool
+	{
+		return in_array($key, $except, true);
+	}
+
+	/**
+	 * Register a callback that instructs the middleware to be skipped.
+	 */
+	public static function skipWhen(Closure $callback): void
+	{
+		static::$skipCallbacks[] = $callback;
+	}
+
+	/**
+	 * Transform the given value.
+	 */
+	protected function transform(string $key, mixed $value): mixed
+	{
+		$except = array_merge($this->except, static::$neverTrim);
+
+		if ($this->shouldSkip($key, $except) || ! is_string($value)) {
+			return $value;
+		}
+
+		return Str::trim($value);
+	}
+}

--- a/src/Framework/Http/Middleware/TrustHosts.php
+++ b/src/Framework/Http/Middleware/TrustHosts.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Http\Middleware;
+
+use Closure;
+use MVPS\Lumis\Framework\Contracts\Framework\Application;
+use MVPS\Lumis\Framework\Http\Request;
+use MVPS\Lumis\Framework\Http\Response;
+
+class TrustHosts
+{
+	/**
+	 * The application instance.
+	 *
+	 * @var \MVPS\Lumis\Framework\Contracts\Framework\Application
+	 */
+	protected Application $app;
+
+	/**
+	 * The trusted hosts that have been configured to always be trusted.
+	 *
+	 * @var array<int, string>|(callable(): array<int, string>)|null
+	 */
+	protected static $alwaysTrust = null;
+
+	/**
+	 * Indicates whether subdomains of the application URL should be trusted.
+	 *
+	 * @var bool|null
+	 */
+	protected static bool|null $subdomains = null;
+
+	/**
+	 * Create a new trust hosts HTTP middleware instance.
+	 */
+	public function __construct(Application $app)
+	{
+		$this->app = $app;
+	}
+
+	/**
+	 * Get a regular expression matching the application URL and all of
+	 * its subdomains.
+	 */
+	protected function allSubdomainsOfApplicationUrl(): string|null
+	{
+		$host = parse_url($this->app['config']->get('app.url'), PHP_URL_HOST);
+
+		if ($host) {
+			return '^(.+\.)?' . preg_quote($host) . '$';
+		}
+
+		return null;
+	}
+
+	/**
+	 * Specify the hosts that should always be trusted.
+	 */
+	public static function at(array|callable $hosts, bool $subdomains = true): void
+	{
+		static::$alwaysTrust = $hosts;
+		static::$subdomains = $subdomains;
+	}
+
+	/**
+	 * Flush the state of the middleware.
+	 */
+	public static function flushState(): void
+	{
+		static::$alwaysTrust = null;
+		static::$subdomains = null;
+	}
+
+	/**
+	 * Handle the incoming request.
+	 */
+	public function handle(Request $request, Closure $next): Response
+	{
+		if ($this->shouldSpecifyTrustedHosts()) {
+			Request::setTrustedHosts(array_filter($this->hosts()));
+		}
+
+		return $next($request);
+	}
+
+	/**
+	 * Get the host patterns that should be trusted.
+	 */
+	public function hosts(): array
+	{
+		if (is_null(static::$alwaysTrust)) {
+			return [$this->allSubdomainsOfApplicationUrl()];
+		}
+
+		$hosts = match (true) {
+			is_array(static::$alwaysTrust) => static::$alwaysTrust,
+			is_callable(static::$alwaysTrust) => call_user_func(static::$alwaysTrust),
+			default => [],
+		};
+
+		if (static::$subdomains) {
+			$hosts[] = $this->allSubdomainsOfApplicationUrl();
+		}
+
+		return $hosts;
+	}
+
+	/**
+	 * Determine if the application should specify trusted hosts.
+	 */
+	protected function shouldSpecifyTrustedHosts(): bool
+	{
+		return ! $this->app->environment('local');
+	}
+}

--- a/src/Framework/Http/Middleware/TrustProxies.php
+++ b/src/Framework/Http/Middleware/TrustProxies.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Http\Middleware;
+
+use Closure;
+use MVPS\Lumis\Framework\Http\Request;
+
+class TrustProxies
+{
+	/**
+	 * The proxies headers that have been configured to always be trusted.
+	 *
+	 * @var int|null
+	 */
+	protected static int|null $alwaysTrustHeaders = null;
+
+	/**
+	 * The proxies that have been configured to always be trusted.
+	 *
+	 * @var array<int, string>|string|null
+	 */
+	protected static array|string|null $alwaysTrustProxies = null;
+
+	/**
+	 * The trusted proxies headers for the application.
+	 *
+	 * @var int
+	 */
+	protected int $headers = Request::HEADER_X_FORWARDED_FOR |
+		Request::HEADER_X_FORWARDED_HOST |
+		Request::HEADER_X_FORWARDED_PORT |
+		Request::HEADER_X_FORWARDED_PROTO |
+		Request::HEADER_X_FORWARDED_AWS_ELB;
+
+		/**
+	 * The trusted proxies for the application.
+	 *
+	 * @var array<int, string>|string|null
+	 */
+	protected array|string|null $proxies = null;
+
+	/**
+	 * Specify the IP addresses of proxies that should always be trusted.
+	 */
+	public static function at(array|string $proxies): void
+	{
+		static::$alwaysTrustProxies = $proxies;
+	}
+
+	/**
+	 * Flush the state of the middleware.
+	 */
+	public static function flushState(): void
+	{
+		static::$alwaysTrustHeaders = null;
+		static::$alwaysTrustProxies = null;
+	}
+
+	/**
+	 * Retrieve trusted header name(s), falling back to defaults if config not set.
+	 */
+	protected function getTrustedHeaderNames(): int
+	{
+		$headers = $this->headers();
+
+		if (is_int($headers)) {
+			return $headers;
+		}
+
+		return match ($headers) {
+			'HEADER_X_FORWARDED_AWS_ELB' => Request::HEADER_X_FORWARDED_AWS_ELB,
+			'HEADER_FORWARDED' => Request::HEADER_FORWARDED,
+			'HEADER_X_FORWARDED_FOR' => Request::HEADER_X_FORWARDED_FOR,
+			'HEADER_X_FORWARDED_HOST' => Request::HEADER_X_FORWARDED_HOST,
+			'HEADER_X_FORWARDED_PORT' => Request::HEADER_X_FORWARDED_PORT,
+			'HEADER_X_FORWARDED_PROTO' => Request::HEADER_X_FORWARDED_PROTO,
+			'HEADER_X_FORWARDED_PREFIX' => Request::HEADER_X_FORWARDED_PREFIX,
+			default =>
+				Request::HEADER_X_FORWARDED_FOR |
+				Request::HEADER_X_FORWARDED_HOST |
+				Request::HEADER_X_FORWARDED_PORT |
+				Request::HEADER_X_FORWARDED_PROTO |
+				Request::HEADER_X_FORWARDED_PREFIX |
+				Request::HEADER_X_FORWARDED_AWS_ELB,
+		};
+	}
+
+	/**
+	 * Handle an incoming request.
+	 *
+	 * @throws \MVPS\Lumis\Framework\Contracts\Http\HttpException
+	 */
+	public function handle(Request $request, Closure $next): mixed
+	{
+		$request::setTrustedProxies([], $this->getTrustedHeaderNames());
+
+		$this->setTrustedProxyIpAddresses($request);
+
+		return $next($request);
+	}
+
+	/**
+	 * Get the trusted headers.
+	 */
+	protected function headers(): int
+	{
+		return static::$alwaysTrustHeaders ?: $this->headers;
+	}
+
+	/**
+	 * Get the trusted proxies.
+	 */
+	protected function proxies(): array|string|null
+	{
+		return static::$alwaysTrustProxies ?: $this->proxies;
+	}
+
+	/**
+	 * Sets the trusted proxies on the request.
+	 */
+	protected function setTrustedProxyIpAddresses(Request $request): void
+	{
+		$trustedIps = $this->proxies() ?: config('trustedproxy.proxies');
+
+		if ($trustedIps === '*' || $trustedIps === '**') {
+			$this->setTrustedProxyIpAddressesToTheCallingIp($request);
+		} else {
+			$trustedIps = is_string($trustedIps)
+				? array_map('trim', explode(',', $trustedIps))
+				: $trustedIps;
+
+			if (is_array($trustedIps)) {
+				$this->setTrustedProxyIpAddressesToSpecificIps($request, $trustedIps);
+			}
+		}
+	}
+
+	/**
+	 * Specify the IP addresses to trust explicitly.
+	 */
+	protected function setTrustedProxyIpAddressesToSpecificIps(Request $request, array $trustedIps): void
+	{
+		$request->setTrustedProxies($trustedIps, $this->getTrustedHeaderNames());
+	}
+
+	/**
+	 * Set the trusted proxy to be the IP address calling this servers.
+	 */
+	protected function setTrustedProxyIpAddressesToTheCallingIp(Request $request): void
+	{
+		$request->setTrustedProxies(
+			[$request->serverBag->get('REMOTE_ADDR')],
+			$this->getTrustedHeaderNames()
+		);
+	}
+
+	/**
+	 * Specify the proxy headers that should always be trusted.
+	 */
+	public static function withHeaders(int $headers): void
+	{
+		static::$alwaysTrustHeaders = $headers;
+	}
+}

--- a/src/Framework/Http/Middleware/ValidatePostSize.php
+++ b/src/Framework/Http/Middleware/ValidatePostSize.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Http\Middleware;
+
+use Closure;
+use MVPS\Lumis\Framework\Http\Exceptions\ContentTooLargeException;
+use MVPS\Lumis\Framework\Http\Request;
+
+class ValidatePostSize
+{
+	/**
+	 * Determine the server 'post_max_size' as bytes.
+	 */
+	protected function getPostMaxSize(): int
+	{
+		$postMaxSize = ini_get('post_max_size');
+
+		if (is_numeric($postMaxSize)) {
+			return (int) $postMaxSize;
+		}
+
+		$metric = strtoupper(substr($postMaxSize, -1));
+
+		$postMaxSize = (int) $postMaxSize;
+
+		return match ($metric) {
+			'K' => $postMaxSize * 1024,
+			'M' => $postMaxSize * 1048576,
+			'G' => $postMaxSize * 1073741824,
+			default => $postMaxSize,
+		};
+	}
+
+	/**
+	 * Handle an incoming request.
+	 *
+	 * @throws \MVPS\Lumis\Framework\Http\Exceptions\ContentTooLargeException
+	 */
+	public function handle(Request $request, Closure $next): mixed
+	{
+		$max = $this->getPostMaxSize();
+
+		if ($max > 0 && $request->server('CONTENT_LENGTH') > $max) {
+			throw new ContentTooLargeException;
+		}
+
+		return $next($request);
+	}
+}

--- a/src/Framework/Http/Request.php
+++ b/src/Framework/Http/Request.php
@@ -2,8 +2,10 @@
 
 namespace MVPS\Lumis\Framework\Http;
 
+use ArrayAccess;
 use Closure;
 use Laminas\Diactoros\ServerRequest;
+use MVPS\Lumis\Framework\Contracts\Support\Arrayable;
 use MVPS\Lumis\Framework\Http\Traits\InteractsWithContent;
 use MVPS\Lumis\Framework\Http\Traits\InteractsWithContentTypes;
 use MVPS\Lumis\Framework\Http\Traits\InteractsWithRequestInput;
@@ -13,14 +15,91 @@ use MVPS\Lumis\Framework\Support\Str;
 use pdeans\Http\Factories\ServerRequestFactory;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UriInterface;
+use RuntimeException;
 use Symfony\Component\HttpFoundation\AcceptHeader;
+use Symfony\Component\HttpFoundation\Exception\ConflictingHeadersException;
+use Symfony\Component\HttpFoundation\FileBag;
+use Symfony\Component\HttpFoundation\HeaderBag;
+use Symfony\Component\HttpFoundation\HeaderUtils;
 use Symfony\Component\HttpFoundation\InputBag;
+use Symfony\Component\HttpFoundation\IpUtils;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\ServerBag;
 
-class Request extends ServerRequest
+class Request extends ServerRequest implements Arrayable, ArrayAccess
 {
 	use InteractsWithContent;
 	use InteractsWithContentTypes;
 	use InteractsWithRequestInput;
+
+	/**
+	 * Bitmask for the `FORWARDED` header (RFC 7239 standard).
+	 */
+	public const HEADER_FORWARDED = 0b000001;
+
+	/**
+	 * Bitmask for the `X_FORWARDED_FOR` header.
+	 */
+	public const HEADER_X_FORWARDED_FOR = 0b000010;
+
+	/**
+	 * Bitmask for the `X_FORWARDED_HOST` header.
+	 */
+	public const HEADER_X_FORWARDED_HOST = 0b000100;
+
+	/**
+	 * Bitmask for the `X_FORWARDED_PROTO` header.
+	 */
+	public const HEADER_X_FORWARDED_PROTO = 0b001000;
+
+	/**
+	 * Bitmask for the `X_FORWARDED_PORT` header.
+	 */
+	public const HEADER_X_FORWARDED_PORT = 0b010000;
+
+	/**
+	 * Bitmask for the `X_FORWARDED_PREFIX` header.
+	 */
+	public const HEADER_X_FORWARDED_PREFIX = 0b100000;
+
+	/**
+	 * Bitmask for headers sent by AWS ELB (excluding X-Forwarded-Host).
+	 */
+	public const HEADER_X_FORWARDED_AWS_ELB = 0b0011010;
+
+	/**
+	 * Bitmask for all "X-Forwarded-*" headers sent by Traefik reverse proxy.
+	 */
+	public const HEADER_X_FORWARDED_TRAEFIK = 0b0111110;
+
+	/**
+	 * Trusted headers for proxy information.
+	 *
+	 * Contains standard and commonly used headers for extracting proxy
+	 * information.
+	 *
+	 * @var array<string, string>
+	 */
+	protected const TRUSTED_HEADERS = [
+		self::HEADER_FORWARDED => 'FORWARDED',
+		self::HEADER_X_FORWARDED_FOR => 'X_FORWARDED_FOR',
+		self::HEADER_X_FORWARDED_HOST => 'X_FORWARDED_HOST',
+		self::HEADER_X_FORWARDED_PROTO => 'X_FORWARDED_PROTO',
+		self::HEADER_X_FORWARDED_PORT => 'X_FORWARDED_PORT',
+		self::HEADER_X_FORWARDED_PREFIX => 'X_FORWARDED_PREFIX',
+	];
+
+	/**
+	 * Mapping of trusted headers to their corresponding parameter names.
+	 *
+	 * @var array<string, string>
+	 */
+	protected const FORWARDED_PARAMS = [
+		self::HEADER_X_FORWARDED_FOR => 'for',
+		self::HEADER_X_FORWARDED_HOST => 'host',
+		self::HEADER_X_FORWARDED_PROTO => 'proto',
+		self::HEADER_X_FORWARDED_PORT => 'host',
+	];
 
 	/**
 	 * The list of acceptable content types.
@@ -28,6 +107,13 @@ class Request extends ServerRequest
 	 * @var array|null
 	 */
 	protected array|null $acceptableContentTypes = null;
+
+	/**
+	 * The parameter bag instance for the custom parameters.
+	 *
+	 * @var \Symfony\Component\HttpFoundation\ParameterBag
+	 */
+	public ParameterBag $attributeBag;
 
 	/**
 	 * The request's root path.
@@ -38,6 +124,27 @@ class Request extends ServerRequest
 	 * The request's root url.
 	 */
 	protected string|null $baseUrl = null;
+
+	/**
+	 * All of the converted files for the request.
+	 *
+	 * @var array|null
+	 */
+	protected array|null $convertedFiles = null;
+
+	/**
+	 * The input bag instance for the cookies ($_COOKIE).
+	 *
+	 * @var \Symfony\Component\HttpFoundation\InputBag
+	 */
+	public InputBag $cookieBag;
+
+	/**
+	 * The file bag for the uploaded files ($_FILES).
+	 *
+	 * @var \Symfony\Component\HttpFoundation\FileBag
+	 */
+	public FileBag $fileBag;
 
 	/**
 	 * The request format MIME types.
@@ -59,21 +166,35 @@ class Request extends ServerRequest
 	];
 
 	/**
-	 * The decoded JSON content for the request.
+	 * The header bag instance for the headers.
+	 *
+	 * @var \Symfony\Component\HttpFoundation\HeaderBag
+	 */
+	public HeaderBag $headerBag;
+
+	/**
+	 * Indicates whether the forwarded headers are valid.
+	 *
+	 * @var bool
+	 */
+	protected bool $isForwardedValid = true;
+
+	/**
+	 * The input bag instance for the decoded JSON content.
 	 *
 	 * @var \Symfony\Component\HttpFoundation\InputBag|null
 	 */
-	protected InputBag|null $json = null;
+	protected InputBag|null $jsonBag = null;
 
 	/**
-	 * The input bag instance for the query string parameters.
+	 * The input bag instance for the query string parameters ($_GET).
 	 *
 	 * @var \Symfony\Component\HttpFoundation\InputBag
 	 */
 	public InputBag $queryBag;
 
 	/**
-	 * The input bag instance for the request parameters.
+	 * The input bag instance for the request parameters ($_POST).
 	 *
 	 * @var \Symfony\Component\HttpFoundation\InputBag
 	 */
@@ -85,6 +206,34 @@ class Request extends ServerRequest
 	 * @var \Closure|null
 	 */
 	protected Closure|null $routeResolver = null;
+
+	/**
+	 * The server bag instance for the server parameters ($_SERVER).
+	 *
+	 * @var \Symfony\Component\HttpFoundation\ServerBag
+	 */
+	public ServerBag $serverBag;
+
+	/**
+	 * Cache for trusted header values.
+	 *
+	 * @var array
+	 */
+	protected array $trustedValuesCache = [];
+
+	/**
+	 * A flag indicating whether the trusted headers have been set.
+	 *
+	 * @var int
+	 */
+	protected static int $trustedHeaderSet = -1;
+
+	/**
+	 * A list of trusted proxy IP addresses or subnets.
+	 *
+	 * @var array<string>
+	 */
+	protected static array $trustedProxies = [];
 
 	public function __construct(
 		array $serverParams = [],
@@ -111,8 +260,13 @@ class Request extends ServerRequest
 			protocol: $protocol
 		);
 
-		$this->queryBag = new InputBag($this->getQueryParams());
 		$this->requestBag = new InputBag((array) $this->getParsedBody());
+		$this->queryBag = new InputBag($this->getQueryParams());
+		$this->attributeBag = new ParameterBag($this->getAttributes());
+		$this->cookieBag = new InputBag($this->getCookieParams());
+		$this->fileBag = new FileBag($this->getUploadedFiles());
+		$this->serverBag = new ServerBag($this->getServerParams());
+		$this->headerBag = new HeaderBag($this->serverBag->getHeaders());
 	}
 
 	/**
@@ -149,6 +303,59 @@ class Request extends ServerRequest
 	public function decodedPath(): string
 	{
 		return rawurldecode($this->getPath());
+	}
+
+	/**
+	 * Filter the given array of files, removing any empty values.
+	 */
+	protected function filterFiles(mixed $files): mixed
+	{
+		if (! $files) {
+			return null;
+		}
+
+		foreach ($files as $key => $file) {
+			if (is_array($file)) {
+				$files[$key] = $this->filterFiles($files[$key]);
+			}
+
+			if (empty($files[$key])) {
+				unset($files[$key]);
+			}
+		}
+
+		return $files;
+	}
+
+	/**
+	 * Generates a unique fingerprint for the request based on
+	 * route, IP address, and HTTP methods.
+	 *
+	 * @throws \RuntimeException
+	 */
+	public function fingerprint(): string
+	{
+		$route = $this->route();
+
+		if (! $route) {
+			throw new RuntimeException('Unable to generate fingerprint. Route unavailable.');
+		}
+
+		return sha1(implode('|', array_merge(
+			$route->methods(),
+			[$route->getDomain(), $route->uri(), $this->ip()]
+		)));
+	}
+
+	/**
+	 * Determine if the current request URL and query string match a pattern.
+	 */
+	public function fullUrlIs(mixed ...$patterns): bool
+	{
+		$url = $this->getFullUrl();
+
+		return collection($patterns)
+			->contains(fn ($pattern) => Str::is($pattern, $url));
 	}
 
 	 /**
@@ -221,7 +428,7 @@ class Request extends ServerRequest
 	 */
 	public function getFullUrl(): string
 	{
-		return $this->getUri();
+		return (string) $this->getUri();
 	}
 
 	/**
@@ -262,6 +469,20 @@ class Request extends ServerRequest
 	public function getHttpHost(): string
 	{
 		return $this->getUri()->getAuthority();
+	}
+
+	/**
+	 * Get the input source for the request.
+	 */
+	protected function getInputSource(): InputBag
+	{
+		if ($this->isJson()) {
+			return $this->json();
+		}
+
+		return in_array($this->getRealMethod(), ['GET', 'HEAD'])
+			? $this->queryBag
+			: $this->requestBag;
 	}
 
 	/**
@@ -348,6 +569,14 @@ class Request extends ServerRequest
 	}
 
 	/**
+	 * Gets the real request method.
+	 */
+	public function getRealMethod(): string
+	{
+		return strtoupper($this->serverBag->get('REQUEST_METHOD', 'GET'));
+	}
+
+	/**
 	 * Get the root URL for the application.
 	 */
 	public function getRoot(): string
@@ -381,6 +610,114 @@ class Request extends ServerRequest
 	}
 
 	/**
+	 * Gets the set of trusted headers from trusted proxies.
+	 */
+	public static function getTrustedHeaderSet(): int
+	{
+		return self::$trustedHeaderSet;
+	}
+
+	/**
+	 * Gets the list of trusted proxies.
+	 */
+	public static function getTrustedProxies(): array
+	{
+		return self::$trustedProxies;
+	}
+
+	/**
+	 * Retrieves trusted values from request headers.
+	 *
+	 * Caches results for performance optimization. Handles header parsing,
+	 * validation, and normalization. Detects and handles conflicting forwarded
+	 * headers.
+	 *
+	 * @throws \Symfony\Component\HttpFoundation\Exception\ConflictingHeadersException
+	 */
+	protected function getTrustedValues(int $type, string|null $ip = null): array
+	{
+		$cacheKey = $type . "\0" . (
+			(static::$trustedHeaderSet & $type)
+				? $this->headerBag->get(static::TRUSTED_HEADERS[$type])
+				: ''
+		);
+
+		$cacheKey .= "\0" . $ip . "\0" . $this->headerBag->get(static::TRUSTED_HEADERS[static::HEADER_FORWARDED]);
+
+		if (isset($this->trustedValuesCache[$cacheKey])) {
+			return $this->trustedValuesCache[$cacheKey];
+		}
+
+		$clientValues = [];
+		$forwardedValues = [];
+
+		if ((static::$trustedHeaderSet & $type) && $this->headerBag->has(static::TRUSTED_HEADERS[$type])) {
+			foreach (explode(',', $this->headerBag->get(static::TRUSTED_HEADERS[$type])) as $val) {
+				$clientValues[] = (static::HEADER_X_FORWARDED_PORT === $type ? '0.0.0.0:' : '') . trim($val);
+			}
+		}
+
+		if (
+			(static::$trustedHeaderSet & static::HEADER_FORWARDED) &&
+			(isset(static::FORWARDED_PARAMS[$type])) &&
+			$this->headerBag->has(static::TRUSTED_HEADERS[static::HEADER_FORWARDED])
+		) {
+			$forwarded = $this->headerBag->get(static::TRUSTED_HEADERS[static::HEADER_FORWARDED]);
+
+			$parts = HeaderUtils::split($forwarded, ',;=');
+
+			$param = static::FORWARDED_PARAMS[$type];
+
+			foreach ($parts as $subParts) {
+				$val = HeaderUtils::combine($subParts)[$param] ?? null;
+
+				if (is_null($val)) {
+					continue;
+				}
+
+				if (static::HEADER_X_FORWARDED_PORT === $type) {
+					$val = strrchr($val, ':');
+
+					if (str_ends_with($val, ']') || $val === false) {
+						$val = $this->isSecure() ? ':443' : ':80';
+					}
+
+					$val = '0.0.0.0' . $val;
+				}
+
+				$forwardedValues[] = $val;
+			}
+		}
+
+		if (! is_null($ip)) {
+			$clientValues = $this->normalizeAndFilterClientIps($clientValues, $ip);
+			$forwardedValues = $this->normalizeAndFilterClientIps($forwardedValues, $ip);
+		}
+
+		if ($forwardedValues === $clientValues || ! $clientValues) {
+			return $this->trustedValuesCache[$cacheKey] = $forwardedValues;
+		}
+
+		if (! $forwardedValues) {
+			return $this->trustedValuesCache[$cacheKey] = $clientValues;
+		}
+
+		if (!$this->isForwardedValid) {
+			return $this->trustedValuesCache[$cacheKey] = ! is_null($ip) ? ['0.0.0.0', $ip] : [];
+		}
+
+		$this->isForwardedValid = false;
+
+		throw new ConflictingHeadersException(sprintf(
+			'The request has both a trusted "%s" header and a trusted "%s" header, conflicting with each other.' .
+				' You should either configure your proxy to remove one of them,' .
+				' or configure your project to distrust the offending one.',
+			static::TRUSTED_HEADERS[static::HEADER_FORWARDED],
+			static::TRUSTED_HEADERS[$type]
+		));
+	}
+
+	/**
 	 * Get the full URL for the request without the query string (if present).
 	 */
 	public function getUrl(): string
@@ -405,6 +742,48 @@ class Request extends ServerRequest
 		}
 
 		return null;
+	}
+
+	/**
+	 * Return the Request instance.
+	 */
+	public function instance(): static
+	{
+		return $this;
+	}
+
+	/**
+	 * Get the client IP address.
+	 */
+	public function ip(): string|null
+	{
+		return $this->ips()[0] ?? null;
+	}
+
+	/**
+	 * Get the client IP addresses.
+	 */
+	public function ips(): array
+	{
+		$ip = $this->serverBag->get('REMOTE_ADDR');
+
+		if (! $this->isFromTrustedProxy()) {
+			return [$ip];
+		}
+
+		return $this->getTrustedValues(static::HEADER_X_FORWARDED_FOR, $ip) ?: [$ip];
+	}
+
+	/**
+	 * Indicates whether this request originated from a trusted proxy.
+	 *
+	 * This can be useful to determine whether or not to trust the
+	 * contents of a proxy-specific header.
+	 */
+	public function isFromTrustedProxy(): bool
+	{
+		return static::$trustedProxies &&
+			IpUtils::checkIp($this->serverBag->get('REMOTE_ADDR', ''), static::$trustedProxies);
 	}
 
 	/**
@@ -439,17 +818,127 @@ class Request extends ServerRequest
 	 */
 	public function json(string|null $key = null, mixed $default = null): mixed
 	{
-		if (! isset($this->json)) {
-			$this->json = new InputBag(
+		if (is_null($this->jsonBag)) {
+			$this->jsonBag = new InputBag(
 				(array) json_decode((string) $this->getBody() ?: '[]', true)
 			);
 		}
 
 		if (is_null($key)) {
-			return $this->json;
+			return $this->jsonBag;
 		}
 
-		return data_get($this->json->all(), $key, $default);
+		return data_get($this->jsonBag->all(), $key, $default);
+	}
+
+	/**
+	 * Merge new input into the current request's input array.
+	 */
+	public function merge(array $input): static
+	{
+		$this->getInputSource()->add($input);
+
+		return $this;
+	}
+
+	/**
+	 * Merges new input into the request's input, preserving existing values.
+	 *
+	 * Only adds input values that are missing from the current request.
+	 */
+	public function mergeIfMissing(array $input): static
+	{
+		return $this->merge(
+			collection($input)->filter(fn ($value, $key) => $this->missing($key))
+				->toArray()
+		);
+	}
+
+	/**
+	 * Normalizes and filters client IP addresses.
+	 *
+	 * Strips ports from IPv4 and IPv6 addresses, validates IP format,
+	 * and filters out trusted proxies. Returns a reversed array of valid client
+	 * IP addresses, or the first trusted IP if no valid addresses are found.
+	 */
+	protected function normalizeAndFilterClientIps(array $clientIps, string $ip): array
+	{
+		if (! $clientIps) {
+			return [];
+		}
+
+		$clientIps[] = $ip;
+		$firstTrustedIp = null;
+
+		foreach ($clientIps as $key => $clientIp) {
+			if (strpos($clientIp, '.')) {
+				// Remove port number from IPv4 addresses. This is allowed in
+				// the Forwarded header and may occur in X-Forwarded-For.
+				$portIndex = strpos($clientIp, ':');
+
+				if ($portIndex) {
+					$clientIps[$key] = $clientIp = substr($clientIp, 0, $portIndex);
+				}
+			} elseif (str_starts_with($clientIp, '[')) {
+				// Remove brackets and port from IPv6 address.
+				$endBracketIndex = strpos($clientIp, ']', 1);
+
+				$clientIps[$key] = $clientIp = substr($clientIp, 1, $endBracketIndex - 1);
+			}
+
+			if (! filter_var($clientIp, FILTER_VALIDATE_IP)) {
+				unset($clientIps[$key]);
+
+				continue;
+			}
+
+			if (IpUtils::checkIp($clientIp, static::$trustedProxies)) {
+				unset($clientIps[$key]);
+
+				// Use the first trusted proxy IP as a fallback if no valid
+				// client IPs are found.
+				$firstTrustedIp ??= $clientIp;
+			}
+		}
+
+		return $clientIps ? array_reverse($clientIps) : [$firstTrustedIp];
+	}
+
+	/**
+	 * Determine if the given offset exists.
+	 */
+	public function offsetExists(mixed $offset): bool
+	{
+		$route = $this->route();
+
+		return Arr::has(
+			$this->all() + ($route ? $route->parameters() : []),
+			$offset
+		);
+	}
+
+	/**
+	 * Get the value at the given offset.
+	 */
+	public function offsetGet(mixed $offset): mixed
+	{
+		return $this->__get($offset);
+	}
+
+	/**
+	 * Set the value at the given offset.
+	 */
+	public function offsetSet(mixed $offset, mixed $value): void
+	{
+		$this->getInputSource()->set($offset, $value);
+	}
+
+	/**
+	 * Remove the value at the given offset.
+	 */
+	public function offsetUnset(mixed $offset): void
+	{
+		$this->getInputSource()->remove($offset);
 	}
 
 	/**
@@ -458,6 +947,16 @@ class Request extends ServerRequest
 	public function pjax(): bool
 	{
 		return $this->hasHeader('X-PJAX');
+	}
+
+	/**
+	 * Determine if the request is the result of a prefetch call.
+	 */
+	public function prefetch(): bool
+	{
+		return strcasecmp($this->serverBag->get('HTTP_X_MOZ') ?? '', 'prefetch') === 0 ||
+			strcasecmp($this->headerBag->get('Purpose') ?? '', 'prefetch') === 0 ||
+			strcasecmp($this->headerBag->get('Sec-Purpose') ?? '', 'prefetch') === 0;
 	}
 
 	/**
@@ -561,6 +1060,16 @@ class Request extends ServerRequest
 	}
 
 	/**
+	 * Replace the input values for the current request.
+	 */
+	public function replace(array $input): static
+	{
+		$this->getInputSource()->replace($input);
+
+		return $this;
+	}
+
+	/**
 	 * Get the route handling the request.
 	 */
 	public function route(string|null $param = null, mixed $default = null): Route|string|null
@@ -585,11 +1094,31 @@ class Request extends ServerRequest
 	}
 
 	/**
+	 * Get a segment from the URI (1 based index).
+	 */
+	public function segment(int $index, string|null $default = null): string|null
+	{
+		return Arr::get($this->segments(), $index - 1, $default);
+	}
+
+	/**
+	 * Get all of the segments for the request path.
+	 */
+	public function segments(): array
+	{
+		$segments = explode('/', $this->decodedPath());
+
+		return array_values(
+			array_filter($segments, fn ($value) => $value !== '')
+		);
+	}
+
+	/**
 	 * Set the JSON payload for the request.
 	 */
 	public function setJson(InputBag $json): static
 	{
-		$this->json = $json;
+		$this->jsonBag = $json;
 
 		return $this;
 	}
@@ -605,6 +1134,42 @@ class Request extends ServerRequest
 	}
 
 	/**
+	 * Sets a list of trusted proxies.
+	 *
+	 * You should only list the reverse proxies that you manage directly.
+	 */
+	public static function setTrustedProxies(array $proxies, int $trustedHeaderSet): void
+	{
+		static::$trustedProxies = array_reduce($proxies, function ($proxies, $proxy) {
+			if ('REMOTE_ADDR' !== $proxy) {
+				$proxies[] = $proxy;
+			} elseif (isset($_SERVER['REMOTE_ADDR'])) {
+				$proxies[] = $_SERVER['REMOTE_ADDR'];
+			}
+
+			return $proxies;
+		}, []);
+
+		static::$trustedHeaderSet = $trustedHeaderSet;
+	}
+
+	/**
+	 * Get all of the input and files for the request.
+	 */
+	public function toArray(): array
+	{
+		return $this->all();
+	}
+
+	/**
+	 * Get the client user agent.
+	 */
+	public function userAgent(): string|null
+	{
+		return $this->headerBag->get('User-Agent');
+	}
+
+	/**
 	 * Check if an input element is set on the request.
 	 */
 	public function __isset(string $key): bool
@@ -617,6 +1182,6 @@ class Request extends ServerRequest
 	 */
 	public function __get(string $key): mixed
 	{
-		return Arr::get($this->input(), $key, fn () => $this->route($key));
+		return Arr::get($this->all(), $key, fn () => $this->route($key));
 	}
 }

--- a/src/Framework/Http/Request.php
+++ b/src/Framework/Http/Request.php
@@ -12,6 +12,7 @@ use MVPS\Lumis\Framework\Support\Arr;
 use MVPS\Lumis\Framework\Support\Str;
 use pdeans\Http\Factories\ServerRequestFactory;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UriInterface;
 use Symfony\Component\HttpFoundation\AcceptHeader;
 use Symfony\Component\HttpFoundation\InputBag;
 
@@ -65,11 +66,54 @@ class Request extends ServerRequest
 	protected InputBag|null $json = null;
 
 	/**
+	 * The input bag instance for the query string parameters.
+	 *
+	 * @var \Symfony\Component\HttpFoundation\InputBag
+	 */
+	public InputBag $queryBag;
+
+	/**
+	 * The input bag instance for the request parameters.
+	 *
+	 * @var \Symfony\Component\HttpFoundation\InputBag
+	 */
+	public InputBag $requestBag;
+
+	/**
 	 * The route resolver callback.
 	 *
 	 * @var \Closure|null
 	 */
 	protected Closure|null $routeResolver = null;
+
+	public function __construct(
+		array $serverParams = [],
+		array $uploadedFiles = [],
+		null|string|UriInterface $uri = null,
+		string|null $method = null,
+		$body = 'php://input',
+		array $headers = [],
+		array $cookieParams = [],
+		array $queryParams = [],
+		$parsedBody = null,
+		string $protocol = '1.1'
+	) {
+		parent::__construct(
+			serverParams: $serverParams,
+			uploadedFiles: $uploadedFiles,
+			uri: $uri,
+			method: $method,
+			body: $body,
+			headers: $headers,
+			cookieParams: $cookieParams,
+			queryParams: $queryParams,
+			parsedBody: $parsedBody,
+			protocol: $protocol
+		);
+
+		$this->queryBag = new InputBag($this->getQueryParams());
+		$this->requestBag = new InputBag((array) $this->getParsedBody());
+	}
 
 	/**
 	 * Determine if the request is the result of an AJAX call.

--- a/src/Framework/Http/Request.php
+++ b/src/Framework/Http/Request.php
@@ -73,6 +73,18 @@ class Request extends ServerRequest implements Arrayable, ArrayAccess
 	public const HEADER_X_FORWARDED_TRAEFIK = 0b0111110;
 
 	/**
+	 * Mapping of trusted headers to their corresponding parameter names.
+	 *
+	 * @var array<string, string>
+	 */
+	protected const FORWARDED_PARAMS = [
+		self::HEADER_X_FORWARDED_FOR => 'for',
+		self::HEADER_X_FORWARDED_HOST => 'host',
+		self::HEADER_X_FORWARDED_PROTO => 'proto',
+		self::HEADER_X_FORWARDED_PORT => 'host',
+	];
+
+	/**
 	 * Trusted headers for proxy information.
 	 *
 	 * Contains standard and commonly used headers for extracting proxy
@@ -87,18 +99,6 @@ class Request extends ServerRequest implements Arrayable, ArrayAccess
 		self::HEADER_X_FORWARDED_PROTO => 'X_FORWARDED_PROTO',
 		self::HEADER_X_FORWARDED_PORT => 'X_FORWARDED_PORT',
 		self::HEADER_X_FORWARDED_PREFIX => 'X_FORWARDED_PREFIX',
-	];
-
-	/**
-	 * Mapping of trusted headers to their corresponding parameter names.
-	 *
-	 * @var array<string, string>
-	 */
-	protected const FORWARDED_PARAMS = [
-		self::HEADER_X_FORWARDED_FOR => 'for',
-		self::HEADER_X_FORWARDED_HOST => 'host',
-		self::HEADER_X_FORWARDED_PROTO => 'proto',
-		self::HEADER_X_FORWARDED_PORT => 'host',
 	];
 
 	/**
@@ -215,13 +215,6 @@ class Request extends ServerRequest implements Arrayable, ArrayAccess
 	public ServerBag $serverBag;
 
 	/**
-	 * Cache for trusted header values.
-	 *
-	 * @var array
-	 */
-	protected array $trustedValuesCache = [];
-
-	/**
 	 * A flag indicating whether the trusted headers have been set.
 	 *
 	 * @var int
@@ -234,6 +227,13 @@ class Request extends ServerRequest implements Arrayable, ArrayAccess
 	 * @var array<string>
 	 */
 	protected static array $trustedProxies = [];
+
+	/**
+	 * Cache for trusted header values.
+	 *
+	 * @var array
+	 */
+	protected array $trustedValuesCache = [];
 
 	public function __construct(
 		array $serverParams = [],

--- a/src/Framework/Http/Request.php
+++ b/src/Framework/Http/Request.php
@@ -222,6 +222,23 @@ class Request extends ServerRequest implements Arrayable, ArrayAccess
 	protected static int $trustedHeaderSet = -1;
 
 	/**
+	 * An array of regular expressions representing the trusted host patterns.
+	 *
+	 * @var array<string>
+	 */
+	protected static array $trustedHostPatterns = [];
+
+	/**
+	 * A list of trusted hosts derived from the trusted host patterns.
+	 *
+	 * This array is populated based on the host patterns and serves as a cache
+	 * of resolved trusted hosts to improve performance during host validation.
+	 *
+	 * @var array<string>
+	 */
+	protected static array $trustedHosts = [];
+
+	/**
 	 * A list of trusted proxy IP addresses or subnets.
 	 *
 	 * @var array<string>
@@ -1131,6 +1148,22 @@ class Request extends ServerRequest implements Arrayable, ArrayAccess
 		$this->routeResolver = $callback;
 
 		return $this;
+	}
+
+	/**
+	 * Sets a list of trusted host patterns.
+	 *
+	 * This method allows you to specify trusted hosts using regular expressions.
+	 * Only include hosts that you directly manage.
+	 */
+	public static function setTrustedHosts(array $hostPatterns): void
+	{
+		self::$trustedHostPatterns = array_map(
+			fn ($hostPattern) => sprintf('{%s}i', $hostPattern),
+			$hostPatterns
+		);
+
+		self::$trustedHosts = [];
 	}
 
 	/**

--- a/src/Framework/Http/Request.php
+++ b/src/Framework/Http/Request.php
@@ -6,6 +6,7 @@ use ArrayAccess;
 use Closure;
 use Laminas\Diactoros\ServerRequest;
 use MVPS\Lumis\Framework\Contracts\Support\Arrayable;
+use MVPS\Lumis\Framework\Http\Traits\CanBePrecognitive;
 use MVPS\Lumis\Framework\Http\Traits\InteractsWithContent;
 use MVPS\Lumis\Framework\Http\Traits\InteractsWithContentTypes;
 use MVPS\Lumis\Framework\Http\Traits\InteractsWithRequestInput;
@@ -28,6 +29,7 @@ use Symfony\Component\HttpFoundation\ServerBag;
 
 class Request extends ServerRequest implements Arrayable, ArrayAccess
 {
+	use CanBePrecognitive;
 	use InteractsWithContent;
 	use InteractsWithContentTypes;
 	use InteractsWithRequestInput;

--- a/src/Framework/Http/Request.php
+++ b/src/Framework/Http/Request.php
@@ -635,6 +635,14 @@ class Request extends ServerRequest implements Arrayable, ArrayAccess
 	}
 
 	/**
+	 * Gets the list of trusted host patterns.
+	 */
+	public static function getTrustedHosts(): array
+	{
+		return self::$trustedHostPatterns;
+	}
+
+	/**
 	 * Gets the list of trusted proxies.
 	 */
 	public static function getTrustedProxies(): array

--- a/src/Framework/Http/Response.php
+++ b/src/Framework/Http/Response.php
@@ -4,6 +4,7 @@ namespace MVPS\Lumis\Framework\Http;
 
 use MVPS\Lumis\Framework\Http\Traits\ResponseTrait;
 use pdeans\Http\Response as BaseResponse;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 class Response extends BaseResponse
 {
@@ -15,6 +16,23 @@ class Response extends BaseResponse
 	 * @var string
 	 */
 	protected string $charset = 'UTF-8';
+
+	/**
+	 * The header bag instance for the headers.
+	 *
+	 * @var \Symfony\Component\HttpFoundation\ResponseHeaderBag
+	 */
+	public ResponseHeaderBag $headerBag;
+
+	/**
+	 * Create a new HTTP response instance.
+	 */
+	public function __construct($body = 'php://memory', int $status = 200, array $headers = [])
+	{
+		parent::__construct(body: $body, status: $status, headers: $headers);
+
+		$this->headerBag = new ResponseHeaderBag($this->getHeaders());
+	}
 
 	/**
 	 * Cleans or flushes output buffers up to target level.

--- a/src/Framework/Http/Traits/CanBePrecognitive.php
+++ b/src/Framework/Http/Traits/CanBePrecognitive.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Http\Traits;
+
+use MVPS\Lumis\Framework\Collections\Collection;
+
+trait CanBePrecognitive
+{
+	/**
+	 * Filter the given array of rules into an array of rules that are
+	 * included in precognitive headers.
+	 */
+	public function filterPrecognitiveRules(array $rules): array
+	{
+		if (! $this->headerBag->has('Precognition-Validate-Only')) {
+			return $rules;
+		}
+
+		return Collection::make($rules)
+			->only(explode(',', $this->header('Precognition-Validate-Only')))
+			->all();
+	}
+
+	/**
+	 * Determine if the request is attempting to be precognitive.
+	 */
+	public function isAttemptingPrecognition(): bool
+	{
+		return $this->header('Precognition') === 'true';
+	}
+
+	/**
+	 * Determine if the request is precognitive.
+	 */
+	public function isPrecognitive(): bool
+	{
+		return $this->attributeBag->get('precognitive', false);
+	}
+}

--- a/src/Framework/Http/Traits/FileHelpers.php
+++ b/src/Framework/Http/Traits/FileHelpers.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Http\Traits;
+
+use MVPS\Lumis\Framework\Support\Str;
+
+trait FileHelpers
+{
+	/**
+	 * The cache copy of the file's hash name.
+	 *
+	 * @var string|null
+	 */
+	protected string|null $hashName = null;
+
+	/**
+	 * Get the dimensions of the image (if applicable).
+	 */
+	public function dimensions(): array|null
+	{
+		return @getimagesize($this->getRealPath());
+	}
+
+	/**
+	 * Get the file's extension.
+	 */
+	public function extension(): string
+	{
+		return $this->guessExtension();
+	}
+
+	/**
+	 * Get a filename for the file.
+	 */
+	public function hashName(string|null $path = null): string
+	{
+		if ($path) {
+			$path = rtrim($path, '/') . '/';
+		}
+
+		$hash = $this->hashName ?: $this->hashName = Str::random(40);
+
+		if ($extension = $this->guessExtension()) {
+			$extension = '.' . $extension;
+		}
+
+		return $path . $hash . $extension;
+	}
+
+	/**
+	 * Get the fully qualified path to the file.
+	 */
+	public function path(): string
+	{
+		return $this->getRealPath();
+	}
+}

--- a/src/Framework/Http/Traits/InteractsWithContent.php
+++ b/src/Framework/Http/Traits/InteractsWithContent.php
@@ -3,8 +3,6 @@
 namespace MVPS\Lumis\Framework\Http\Traits;
 
 use ArrayObject;
-use InvalidArgumentException;
-use JsonException;
 use JsonSerializable;
 use MVPS\Lumis\Framework\Contracts\Support\Arrayable;
 use MVPS\Lumis\Framework\Contracts\Support\Jsonable;
@@ -12,6 +10,20 @@ use stdClass;
 
 trait InteractsWithContent
 {
+	/**
+	 * Transform the given content to JSON.
+	 */
+	public function morphToJson(mixed $content): string|false
+	{
+		if ($content instanceof Jsonable) {
+			return $content->toJson();
+		} elseif ($content instanceof Arrayable) {
+			return json_encode($content->toArray());
+		}
+
+		return json_encode($content);
+	}
+
 	/**
 	 * Determine if the given content should be transformed into JSON.
 	 */
@@ -23,23 +35,5 @@ trait InteractsWithContent
 			$content instanceof JsonSerializable ||
 			$content instanceof stdClass ||
 			is_array($content);
-	}
-
-	/**
-	 * Transform the given content to JSON.
-	 *
-	 * @throws \InvalidArgumentException
-	 */
-	public function transformToJson(mixed $content): string
-	{
-		try {
-			return json_encode($content, JSON_THROW_ON_ERROR);
-		} catch (JsonException $exception) {
-			throw new InvalidArgumentException(
-				'Unable to encode data to JSON in ' . static::class . ': ' . $exception->getMessage(),
-				0,
-				$exception
-			);
-		}
 	}
 }

--- a/src/Framework/Http/Traits/InteractsWithRequestInput.php
+++ b/src/Framework/Http/Traits/InteractsWithRequestInput.php
@@ -325,14 +325,6 @@ trait InteractsWithRequestInput
 	}
 
 	/**
-	 * Retrieve the JSON payload from the request.
-	 */
-	public function json(string|null $key = null, string|array|null $default = null): string|array|null
-	{
-		return data_get(json_decode((string) $this->getBody(), true), $key, $default);
-	}
-
-	/**
 	 * Get all of the query string items for the request, or a specific query string item with the given key.
 	 */
 	public function query(string|null $key = null, mixed $default = null): mixed

--- a/src/Framework/Http/Traits/ResponseTrait.php
+++ b/src/Framework/Http/Traits/ResponseTrait.php
@@ -2,6 +2,8 @@
 
 namespace MVPS\Lumis\Framework\Http\Traits;
 
+use MVPS\Lumis\Framework\Http\Exceptions\HttpResponseException;
+use Symfony\Component\HttpFoundation\HeaderBag;
 use Throwable;
 
 trait ResponseTrait
@@ -21,6 +23,30 @@ trait ResponseTrait
 	public mixed $original = null;
 
 	/**
+	 * Get the body content of the response.
+	 */
+	public function content(): string
+	{
+		return (string) $this->getBody();
+	}
+
+	/**
+	 * Add a cookie to the response.
+	 */
+	public function cookie(mixed $cookie): static
+	{
+		return $this->withCookie(...func_get_args());
+	}
+
+	/**
+	 * Get the callback of the response.
+	 */
+	public function getCallback(): string|null
+	{
+		return $this->callback ?? null;
+	}
+
+	/**
 	 * Get the original response content.
 	 */
 	public function getOriginalContent(): mixed
@@ -31,11 +57,78 @@ trait ResponseTrait
 	}
 
 	/**
+	 * Set a header on the Response.
+	 */
+	public function header(string $key, array|string $values, bool $replace = true): static
+	{
+		$this->headerBag->set($key, $values, $replace);
+
+		return $this;
+	}
+
+	/**
+	 * Throws an instance of HttpResponseException with the current response.
+	 *
+	 * This method halts execution by throwing an exception that encapsulates the
+	 * current HTTP response, allowing the framework to handle it appropriately.
+	 *
+	 * @throws \MVPS\Lumis\Framework\Http\Exceptions\HttpResponseException
+	 */
+	public function throwResponse(): void
+	{
+		throw new HttpResponseException($this);
+	}
+
+	/**
+	 * Add a cookie to the response.
+	 */
+	public function withCookie(mixed $cookie): static
+	{
+		if (is_string($cookie) && function_exists('cookie')) {
+			$cookie = cookie(...func_get_args());
+		}
+
+		$this->headerBag->setCookie($cookie);
+
+		return $this;
+	}
+
+	/**
 	 * Set the exception to attach to the response.
 	 */
 	public function withException(Throwable $e): static
 	{
 		$this->exception = $e;
+
+		return $this;
+	}
+
+	/**
+	 * Add an array of headers to the response.
+	 */
+	public function withHeaders(HeaderBag|array $headers): static
+	{
+		if ($headers instanceof HeaderBag) {
+			$headers = $headers->all();
+		}
+
+		foreach ($headers as $key => $value) {
+			$this->headerBag->set($key, $value);
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Expire a cookie when sending the response.
+	 */
+	public function withoutCookie(mixed $cookie, string|null $path = null, string|null $domain = null): static
+	{
+		if (is_string($cookie) && function_exists('cookie')) {
+			$cookie = cookie($cookie, null, -2628000, $path, $domain);
+		}
+
+		$this->headerBag->setCookie($cookie);
 
 		return $this;
 	}

--- a/src/Framework/Http/UploadedFile.php
+++ b/src/Framework/Http/UploadedFile.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Http;
+
+use Illuminate\Support\Traits\Macroable;
+use MVPS\Lumis\Framework\Container\Container;
+use MVPS\Lumis\Framework\Contracts\Filesystem\Factory as FilesystemFactory;
+use MVPS\Lumis\Framework\Filesystem\Exceptions\FileNotFoundException;
+use MVPS\Lumis\Framework\Http\Traits\FileHelpers;
+use MVPS\Lumis\Framework\Support\Arr;
+use Symfony\Component\HttpFoundation\File\UploadedFile as SymfonyUploadedFile;
+
+class UploadedFile extends SymfonyUploadedFile
+{
+	use FileHelpers;
+	use Macroable;
+
+	/**
+	 * Get the file's extension supplied by the client.
+	 */
+	public function clientExtension(): string
+	{
+		return $this->guessClientExtension();
+	}
+
+	/**
+	 * Get the contents of the uploaded file.
+	 *
+	 * @throws \MVPS\Lumis\Framework\Filesystem\Exceptions\FileNotFoundException
+	 */
+	public function get(): false|string
+	{
+		if (! $this->isValid()) {
+			throw new FileNotFoundException("File does not exist at path {$this->getPathname()}.");
+		}
+
+		return file_get_contents($this->getPathname());
+	}
+
+	/**
+	 * Create a new file instance from a base instance.
+	 */
+	public static function createFromBase(SymfonyUploadedFile $file, bool $test = false): static
+	{
+		return $file instanceof static ? $file : new static(
+			$file->getPathname(),
+			$file->getClientOriginalName(),
+			$file->getClientMimeType(),
+			$file->getError(),
+			$test
+		);
+	}
+
+	/**
+	 * Parse and format the given options.
+	 */
+	protected function parseOptions(array|string $options): array
+	{
+		if (is_string($options)) {
+			$options = ['disk' => $options];
+		}
+
+		return $options;
+	}
+
+	/**
+	 * Store the uploaded file on a filesystem disk.
+	 */
+	public function store(string $path = '', array|string $options = []): string|false
+	{
+		return $this->storeAs($path, $this->hashName(), $this->parseOptions($options));
+	}
+
+	/**
+	 * Store the uploaded file on a filesystem disk.
+	 */
+	public function storeAs(string $path, string|array $name = null, array|string $options = []): string|false
+	{
+		if (is_null($name) || is_array($name)) {
+			[$path, $name, $options] = ['', $path, $name ?? []];
+		}
+
+		$options = $this->parseOptions($options);
+
+		$disk = Arr::pull($options, 'disk');
+
+		return Container::getInstance()->make(FilesystemFactory::class)
+			->disk($disk)
+			->putFileAs($path, $this, $name, $options);
+	}
+
+	/**
+	 * Store the uploaded file on a filesystem disk with public visibility.
+	 */
+	public function storePublicly(string $path = '', array|string $options = []): string|false
+	{
+		$options = $this->parseOptions($options);
+
+		$options['visibility'] = 'public';
+
+		return $this->storeAs($path, $this->hashName(), $options);
+	}
+
+	/**
+	 * Store the uploaded file on a filesystem disk with public visibility.
+	 */
+	public function storePubliclyAs(string $path, string $name = null, array|string $options = []): string|false
+	{
+		if (is_null($name) || is_array($name)) {
+			[$path, $name, $options] = ['', $path, $name ?? []];
+		}
+
+		$options = $this->parseOptions($options);
+
+		$options['visibility'] = 'public';
+
+		return $this->storeAs($path, $name, $options);
+	}
+}

--- a/src/Framework/Providers/FrameworkServiceProvider.php
+++ b/src/Framework/Providers/FrameworkServiceProvider.php
@@ -106,6 +106,7 @@ class FrameworkServiceProvider extends AggregateServiceProvider
 
 			return new Renderer(
 				$app->make(ViewFactoryContract::class),
+				$app->make(Listener::class),
 				$errorRenderer,
 				$app->make(BladeMapper::class),
 				$app->basePath()

--- a/src/Framework/Providers/FrameworkServiceProvider.php
+++ b/src/Framework/Providers/FrameworkServiceProvider.php
@@ -9,6 +9,7 @@ use MVPS\Lumis\Framework\Contracts\Framework\Application as ApplicationContract;
 use MVPS\Lumis\Framework\Contracts\View\Factory as ViewFactoryContract;
 use MVPS\Lumis\Framework\Debugging\CliDumper;
 use MVPS\Lumis\Framework\Debugging\HtmlDumper;
+use MVPS\Lumis\Framework\Exceptions\Renderer\Listener;
 use MVPS\Lumis\Framework\Exceptions\Renderer\Mappers\BladeMapper;
 use MVPS\Lumis\Framework\Exceptions\Renderer\Renderer;
 use MVPS\Lumis\Framework\Http\Client\Factory as HttpFactory;
@@ -29,6 +30,24 @@ class FrameworkServiceProvider extends AggregateServiceProvider
 	public array $singletons = [
 		HttpFactory::class => HttpFactory::class,
 	];
+
+	/**
+	 * Boot the framework service provider.
+	 */
+	public function boot(): void
+	{
+		if ($this->app->runningInConsole()) {
+			$this->publishes(
+				[__DIR__ . '/../Exceptions/views' => $this->app->resourcePath('views/errors/')],
+				'lumis-errors'
+			);
+		}
+
+		if ($this->app->hasDebugModeEnabled()) {
+			$this->app->make(Listener::class)
+				->registerListeners($this->app->make(Dispatcher::class));
+		}
+	}
 
 	/**
 	 * Register the framework service provider.

--- a/src/Framework/Routing/AbstractRouteCollection.php
+++ b/src/Framework/Routing/AbstractRouteCollection.php
@@ -7,8 +7,8 @@ use Countable;
 use IteratorAggregate;
 use LogicException;
 use MVPS\Lumis\Framework\Contracts\Routing\RouteCollection as RouteCollectionContract;
-use MVPS\Lumis\Framework\Http\Exceptions\MethodNotAllowedHttpException;
-use MVPS\Lumis\Framework\Http\Exceptions\NotFoundHttpException;
+use MVPS\Lumis\Framework\Http\Exceptions\MethodNotAllowedException;
+use MVPS\Lumis\Framework\Http\Exceptions\NotFoundException;
 use MVPS\Lumis\Framework\Http\Request;
 use MVPS\Lumis\Framework\Support\Str;
 use Symfony\Component\Routing\Matcher\Dumper\CompiledUrlMatcherDumper;
@@ -123,7 +123,7 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
 	/**
 	 * Get a route (if necessary) that responds when other available methods are present.
 	 *
-	 * @throws \MVPS\Lumis\Framework\Http\Exceptions\MethodNotAllowedHttpException
+	 * @throws \MVPS\Lumis\Framework\Http\Exceptions\MethodNotAllowedException
 	 */
 	protected function getRouteForMethods(Request $request, array $methods): Route
 	{
@@ -139,7 +139,7 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
 	/**
 	 * Handle the matched route.
 	 *
-	 * @throws \MVPS\Lumis\Framework\Http\Exceptions\NotFoundHttpException
+	 * @throws \MVPS\Lumis\Framework\Http\Exceptions\NotFoundException
 	 */
 	protected function handleMatchedRoute(Request $request, Route|null $route): Route
 	{
@@ -156,7 +156,7 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
 			return $this->getRouteForMethods($request, $others);
 		}
 
-		throw new NotFoundHttpException(sprintf('The route %s could not be found.', $request->getPath()));
+		throw new NotFoundException(sprintf('The route %s could not be found.', $request->getPath()));
 	}
 
 	/**
@@ -177,11 +177,11 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
 	/**
 	 * Throw a method not allowed HTTP exception.
 	 *
-	 * @throws \MVPS\Lumis\Framework\Http\Exceptions\MethodNotAllowedHttpException
+	 * @throws \MVPS\Lumis\Framework\Http\Exceptions\MethodNotAllowedException
 	 */
 	protected function requestMethodNotAllowed(Request $request, array $others, string $method): void
 	{
-		throw new MethodNotAllowedHttpException(
+		throw new MethodNotAllowedException(
 			$others,
 			sprintf(
 				'The %s method is not supported for route %s. Supported methods: %s.',

--- a/src/Framework/Routing/PrecognitionCallableDispatcher.php
+++ b/src/Framework/Routing/PrecognitionCallableDispatcher.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Routing;
+
+class PrecognitionCallableDispatcher extends CallableDispatcher
+{
+	/**
+	 * Dispatch a request to a given callable.
+	 */
+	public function dispatch(Route $route, callable $callable): mixed
+	{
+		$this->resolveParameters($route, $callable);
+
+		abort(204, headers: ['Precognition-Success' => 'true']);
+	}
+}

--- a/src/Framework/Routing/PrecognitionControllerDispatcher.php
+++ b/src/Framework/Routing/PrecognitionControllerDispatcher.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Routing;
+
+use RuntimeException;
+
+class PrecognitionControllerDispatcher extends ControllerDispatcher
+{
+	/**
+	 * Dispatch a request to a given controller and method.
+	 */
+	public function dispatch(Route $route, mixed $controller, string $method): void
+	{
+		$this->ensureMethodExists($controller, $method);
+
+		$this->resolveParameters($route, $controller, $method);
+
+		abort(204, headers: ['Precognition-Success' => 'true']);
+	}
+
+	/**
+	 * Ensure that the given method exists on the controller.
+	 */
+	protected function ensureMethodExists(object $controller, string $method): static
+	{
+		if (method_exists($controller, $method)) {
+			return $this;
+		}
+
+		$class = $controller::class;
+
+		throw new RuntimeException(
+			"Attempting to predict the outcome of the [{$class}::{$method}()] method but the method is not defined."
+		);
+	}
+}

--- a/src/Framework/Routing/RouteCollection.php
+++ b/src/Framework/Routing/RouteCollection.php
@@ -151,8 +151,8 @@ class RouteCollection extends AbstractRouteCollection
 	/**
 	 * Find the first route matching a given request.
 	 *
-	 * @throws \MVPS\Lumis\Framework\Http\Exceptions\MethodNotAllowedHttpException
-	 * @throws \MVPS\Lumis\Framework\Http\Exceptions\NotFoundHttpException
+	 * @throws \MVPS\Lumis\Framework\Http\Exceptions\MethodNotAllowedException
+	 * @throws \MVPS\Lumis\Framework\Http\Exceptions\NotFoundException
 	 */
 	public function match(Request $request): Route
 	{

--- a/src/Framework/config/filesystems.php
+++ b/src/Framework/config/filesystems.php
@@ -1,0 +1,53 @@
+<?php
+
+return [
+
+	/*
+	|--------------------------------------------------------------------------
+	| Default Filesystem Disk
+	|--------------------------------------------------------------------------
+	|
+	| Configure the default filesystem disk used for file storage operations.
+	| Available disks include "local" and various cloud storage options.
+	|
+	*/
+	'default' => env('FILESYSTEM_DISK', 'local'),
+
+	/*
+	|--------------------------------------------------------------------------
+	| Filesystem Disks
+	|--------------------------------------------------------------------------
+	|
+	| Configure multiple filesystem disks for various storage needs.
+	| Define disks with their driver, root path, and optional configurations.
+	| Supported drivers include "local", "ftp", and "sftp".
+	|
+	*/
+	'disks' => [
+		'local' => [
+			'driver' => 'local',
+			'root' => storage_path('app'),
+			'throw' => false,
+		],
+		'public' => [
+			'driver' => 'local',
+			'root' => storage_path('app/public'),
+			'url' => env('APP_URL') . '/storage',
+			'visibility' => 'public',
+			'throw' => false,
+		],
+	],
+
+	/*
+	|--------------------------------------------------------------------------
+	| Symbolic Links
+	|--------------------------------------------------------------------------
+	|
+	| Define symbolic links to be created by the `storage:link` Lumis command.
+	| Map link paths (array keys) to their target directories (array values).
+	|
+	*/
+	'links' => [
+		public_path('storage') => storage_path('app/public'),
+	],
+];

--- a/src/Framework/helpers.php
+++ b/src/Framework/helpers.php
@@ -226,7 +226,7 @@ if (! function_exists('request')) {
 			return $request->only($key);
 		}
 
-		$value = $request->input($key);
+		$value = app('request')->__get($key);
 
 		return is_null($value) ? value($default) : $value;
 	}

--- a/src/Framework/helpers.php
+++ b/src/Framework/helpers.php
@@ -213,6 +213,32 @@ if (! function_exists('now')) {
 	}
 }
 
+if (! function_exists('precognitive')) {
+	/**
+	 * Handle a precognition controller hook.
+	 */
+	function precognitive(null|callable $callable = null): mixed
+	{
+		$callable ??= function () {
+			//
+		};
+
+		$payload = $callable(function ($default, $precognition = null) {
+			$response = request()->isPrecognitive()
+				? ($precognition ?? $default)
+				: $default;
+
+			abort(app('router')->toResponse(request(), value($response)));
+		});
+
+		if (request()->isPrecognitive()) {
+			abort(204, headers: ['Precognition-Success' => 'true']);
+		}
+
+		return $payload;
+	}
+}
+
 if (! function_exists('public_path')) {
 	/**
 	 * Get the path to the public directory.

--- a/src/Framework/helpers.php
+++ b/src/Framework/helpers.php
@@ -5,15 +5,39 @@ use Faker\Factory as FakerFactory;
 use Faker\Generator as FakerGenerator;
 use MVPS\Lumis\Framework\Container\Container;
 use MVPS\Lumis\Framework\Contracts\Exceptions\ExceptionHandler;
+use MVPS\Lumis\Framework\Contracts\Http\Responsable;
 use MVPS\Lumis\Framework\Contracts\Routing\UrlGenerator;
 use MVPS\Lumis\Framework\Contracts\Support\Arrayable;
 use MVPS\Lumis\Framework\Contracts\View\Factory as ViewFactory;
 use MVPS\Lumis\Framework\Contracts\View\View;
+use MVPS\Lumis\Framework\Http\Exceptions\HttpResponseException;
 use MVPS\Lumis\Framework\Http\Request;
 use MVPS\Lumis\Framework\Http\Response;
 use MVPS\Lumis\Framework\Http\ResponseFactory;
 use MVPS\Lumis\Framework\Support\HtmlString;
 use MVPS\Lumis\Framework\Support\Str;
+
+if (! function_exists('abort')) {
+	/**
+	 * Terminates execution and generates an HTTP response.
+	 *
+	 * Creates an appropriate HTTP exception based on the provided data.
+	 *
+	 * @throws \MVPS\Lumis\Framework\Http\Exceptions\HttpException
+	 * @throws \MVPS\Lumis\Framework\Http\Exceptions\NotFoundException
+	 * @throws \MVPS\Lumis\Framework\Http\Exceptions\HttpResponseException
+	 */
+	function abort(Response|Responsable|int $code, string $message = '', array $headers = []): never
+	{
+		if ($code instanceof Response) {
+			throw new HttpResponseException($code);
+		} elseif ($code instanceof Responsable) {
+			throw new HttpResponseException($code->toResponse(request()));
+		}
+
+		app()->abort($code, $message, $headers);
+	}
+}
 
 if (! function_exists('action')) {
 	/**

--- a/src/Framework/helpers.php
+++ b/src/Framework/helpers.php
@@ -10,12 +10,14 @@ use MVPS\Lumis\Framework\Contracts\Routing\UrlGenerator;
 use MVPS\Lumis\Framework\Contracts\Support\Arrayable;
 use MVPS\Lumis\Framework\Contracts\View\Factory as ViewFactory;
 use MVPS\Lumis\Framework\Contracts\View\View;
+use MVPS\Lumis\Framework\Http\Client\Cookies\CookieJar;
 use MVPS\Lumis\Framework\Http\Exceptions\HttpResponseException;
 use MVPS\Lumis\Framework\Http\Request;
 use MVPS\Lumis\Framework\Http\Response;
 use MVPS\Lumis\Framework\Http\ResponseFactory;
 use MVPS\Lumis\Framework\Support\HtmlString;
 use MVPS\Lumis\Framework\Support\Str;
+use Symfony\Component\HttpFoundation\Cookie;
 
 if (! function_exists('abort')) {
 	/**
@@ -112,6 +114,31 @@ if (! function_exists('config_path')) {
 		return app()->configPath($path);
 	}
 }
+
+// if (! function_exists('cookie')) {
+// 	/**
+// 	 * Create a new cookie instance.
+// 	 */
+// 	function cookie(
+// 		string|null $name = null,
+// 		string|null $value = null,
+// 		int $minutes = 0,
+// 		string|null $path = null,
+// 		string|null $domain = null,
+// 		bool|null $secure = null,
+// 		bool $httpOnly = true,
+// 		bool $raw = false,
+// 		string|null $sameSite = null
+// 	): CookieJar|Cookie {
+// 		$cookie = app(CookieFactory::class);
+
+// 		if (is_null($name)) {
+// 			return $cookie;
+// 		}
+
+// 		return $cookie->make($name, $value, $minutes, $path, $domain, $secure, $httpOnly, $raw, $sameSite);
+// 	}
+// }
 
 if (! function_exists('database_path')) {
 	/**

--- a/src/Framework/helpers.php
+++ b/src/Framework/helpers.php
@@ -121,6 +121,24 @@ if (! function_exists('fake') && class_exists(FakerFactory::class)) {
 	}
 }
 
+if (! function_exists('join_paths')) {
+	/**
+	 * Join the given paths together.
+	 */
+	function join_paths(string|null $basePath, string ...$paths): string
+	{
+		foreach ($paths as $index => $path) {
+			if (empty($path) && $path !== '0') {
+				unset($paths[$index]);
+			} else {
+				$paths[$index] = DIRECTORY_SEPARATOR . ltrim($path, DIRECTORY_SEPARATOR);
+			}
+		}
+
+		return $basePath . implode('', $paths);
+	}
+}
+
 if (! function_exists('method_field')) {
 	/**
 	 * Generate a hidden form field to spoof the HTTP verb used by the form.

--- a/src/Framework/resources/exceptions/renderer/components/layout.blade.php
+++ b/src/Framework/resources/exceptions/renderer/components/layout.blade.php
@@ -1,3 +1,4 @@
+@use('MVPS\Lumis\Framework\Exceptions\Renderer\Renderer')
 <!DOCTYPE html>
 <html lang="en">
 	<head>
@@ -16,7 +17,7 @@
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 		<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
 
-		{!! MVPS\Lumis\Framework\Exceptions\Renderer\Renderer::css() !!}
+		{!! Renderer::css() !!}
 
 		<style type="text/css">
 			@foreach ($exception->frames() as $frame)
@@ -29,7 +30,7 @@
 	<body class="bg-gray-200/80 font-sans antialiased dark:bg-gray-950/95">
 		{{ $slot }}
 
-		{!! MVPS\Lumis\Framework\Exceptions\Renderer\Renderer::js() !!}
+		{!! Renderer::js() !!}
 
 		<script type="text/javascript">
 			!function(r,o){"use strict";var e,i="hljs-ln",l="hljs-ln-line",h="hljs-ln-code",s="hljs-ln-numbers",c="hljs-ln-n",m="data-line-number",a=/\r\n|\r|\n/g;function u(e){for(var n=e.toString(),t=e.anchorNode;"TD"!==t.nodeName;)t=t.parentNode;for(var r=e.focusNode;"TD"!==r.nodeName;)r=r.parentNode;var o=parseInt(t.dataset.lineNumber),a=parseInt(r.dataset.lineNumber);if(o==a)return n;var i,l=t.textContent,s=r.textContent;for(a<o&&(i=o,o=a,a=i,i=l,l=s,s=i);0!==n.indexOf(l);)l=l.slice(1);for(;-1===n.lastIndexOf(s);)s=s.slice(0,-1);for(var c=l,u=function(e){for(var n=e;"TABLE"!==n.nodeName;)n=n.parentNode;return n}(t),d=o+1;d<a;++d){var f=p('.{0}[{1}="{2}"]',[h,m,d]);c+="\n"+u.querySelector(f).textContent}return c+="\n"+s}function n(e){try{var n=o.querySelectorAll("code.hljs,code.nohighlight");for(var t in n)n.hasOwnProperty(t)&&(n[t].classList.contains("nohljsln")||d(n[t],e))}catch(e){r.console.error("LineNumbers error: ",e)}}function d(e,n){"object"==typeof e&&r.setTimeout(function(){e.innerHTML=f(e,n)},0)}function f(e,n){var t,r,o=(t=e,{singleLine:function(e){return!!e.singleLine&&e.singleLine}(r=(r=n)||{}),startFrom:function(e,n){var t=1;isFinite(n.startFrom)&&(t=n.startFrom);var r=function(e,n){return e.hasAttribute(n)?e.getAttribute(n):null}(e,"data-ln-start-from");return null!==r&&(t=function(e,n){if(!e)return n;var t=Number(e);return isFinite(t)?t:n}(r,1)),t}(t,r)});return function e(n){var t=n.childNodes;for(var r in t){var o;t.hasOwnProperty(r)&&(o=t[r],0<(o.textContent.trim().match(a)||[]).length&&(0<o.childNodes.length?e(o):v(o.parentNode)))}}(e),function(e,n){var t=g(e);""===t[t.length-1].trim()&&t.pop();if(1<t.length||n.singleLine){for(var r="",o=0,a=t.length;o<a;o++)r+=p('<tr><td class="{0} {1}" {3}="{5}"><div class="{2}" {3}="{5}"></div></td><td class="{0} {4}" {3}="{5}">{6}</td></tr>',[l,s,c,m,h,o+n.startFrom,0<t[o].length?t[o]:" "]);return p('<table class="{0}">{1}</table>',[i,r])}return e}(e.innerHTML,o)}function v(e){var n=e.className;if(/hljs-/.test(n)){for(var t=g(e.innerHTML),r=0,o="";r<t.length;r++){o+=p('<span class="{0}">{1}</span>\n',[n,0<t[r].length?t[r]:" "])}e.innerHTML=o.trim()}}function g(e){return 0===e.length?[]:e.split(a)}function p(e,t){return e.replace(/\{(\d+)\}/g,function(e,n){return void 0!==t[n]?t[n]:e})}r.hljs?(r.hljs.initLineNumbersOnLoad=function(e){"interactive"===o.readyState||"complete"===o.readyState?n(e):r.addEventListener("DOMContentLoaded",function(){n(e)})},r.hljs.lineNumbersBlock=d,r.hljs.lineNumbersValue=function(e,n){if("string"!=typeof e)return;var t=document.createElement("code");return t.innerHTML=e,f(t,n)},(e=o.createElement("style")).type="text/css",e.innerHTML=p(".{0}{border-collapse:collapse}.{0} td{padding:0}.{1}:before{content:attr({2})}",[i,c,m]),o.getElementsByTagName("head")[0].appendChild(e)):r.console.error("highlight.js not detected!"),document.addEventListener("copy",function(e){var n,t=window.getSelection();!function(e){for(var n=e;n;){if(n.className&&-1!==n.className.indexOf("hljs-ln-code"))return 1;n=n.parentNode}}(t.anchorNode)||(n=-1!==window.navigator.userAgent.indexOf("Edge")?u(t):t.toString(),e.clipboardData.setData("text/plain",n),e.preventDefault())})}(window,document);


### PR DESCRIPTION
## Change Log

### Fixes

- Updated `renderForConsole` in `MVPS\Lumis\Framework\Exceptions\Handler` to throw symfony console application errors if the console error is a symfony console exception

### New Features & Enhancements

- Added `MVPS\Lumis\Framework\Exceptions\Renderer\Listener`
- Updated `MVPS\Lumis\Framework\Exceptions\Renderer\Exception`:
	- Added properties:
		- `listener`
	- Added methods:
		- `applicationQueries`
- Added `listener` property to `MVPS\Lumis\Framework\Exceptions\Renderer\Renderer`:
- Updated `MVPS\Lumis\Framework\Providers\ServiceProvider`:
	- Added properties:
		- `publishes` (static)
		- `publishGroups` (static)
		- `publishableMigrationPaths` (static)
	- Added methods:
		- `addPublishGroup`
		- `ensurePublishArrayInitialized`
		- `pathsForProviderAndGroup`
		- `pathsForProviderOrGroup`
		- `pathsToPublish`
		- `publishableMigrationPaths`
		- `publishableGroups`
		- `publishableProviders`
		- `publishes`
		- `publishesMigrations`
- Added `boot` method to `MVPS\Lumis\Framework\Providers\FrameworkServiceProvider`
- Updated `MVPS\Lumis\Framework\Http\Request`:
	- Implements interfaces:
		- `ArrayAccess`
		- `MVPS\Lumis\Framework\Contracts\Support\Arrayable`
	- Added `MVPS\Lumis\Framework\Http\Traits\CanBePrecognitive` trait usage
	- Added properties:
		- `HEADER_FORWARDED` (constant)
		- `HEADER_X_FORWARDED_FOR` (constant)
		- `HEADER_X_FORWARDED_HOST` (constant)
		- `HEADER_X_FORWARDED_PROTO` (constant)
		- `HEADER_X_FORWARDED_PORT` (constant)
		- `HEADER_X_FORWARDED_PREFIX` (constant)
		- `HEADER_X_FORWARDED_AWS_ELB` (constant)
		- `HEADER_X_FORWARDED_TRAEFIK` (constant)
		- `TRUSTED_HEADERS` (constant)
		- `FORWARDED_PARAMS` (constant)
		- `attributeBag`
		- `convertedFiles`
		- `cookieBag`
		- `fileBag`
		- `headerBag`
		- `isForwardedValid`
		- `jsonBag`
		- `queryBag`
		- `requestBag`
		- `serverBag`
		- `trustedHeaderSet` (static)
		- `trustedHostPatterns` (static)
		- `trustedHosts` (static)
		- `trustedProxies` (static)
		- `trustedValuesCache` (static)
	- Added methods:
		- `__construct`
		- `filterFiles`
		- `fingerprint`
		- `fullUrlIs`
		- `getInputSource`
		- `getRealMethod`
		- `getTrustedHeaderSet`
		- `getTrustedHosts`
		- `getTrustedProxies`
		- `getTrustedValues`
		- `instance`
		- `ip`
		- `ips`
		- `isFromTrustedProxy`
		- `json`
		- `merge`
		- `mergeIfMissing`
		- `normalizeAndFilterClientIps`
		- `offsetExists`
		- `offsetGet`
		- `offsetSet`
		- `offsetUnset`
		- `prefetch`
		- `replace`
		- `segment`
		- `segments`
		- `setJson`
		- `setTrustedProxies` (static)
		- `toArray`
		- `userAgent`
- Added `MVPS\Lumis\Framework\Http\Middleware\ConvertEmptyStringsToNull`
- Added `MVPS\Lumis\Framework\Http\Middleware\HandlePrecognitiveRequests`
- Added `MVPS\Lumis\Framework\Http\Middleware\TransformsRequest`
- Added `MVPS\Lumis\Framework\Http\Middleware\TrimStrings`
- Added `MVPS\Lumis\Framework\Http\Middleware\TrustHosts`
- Added `MVPS\Lumis\Framework\Http\Middleware\TrustProxies`
- Added `MVPS\Lumis\Framework\Http\Middleware\ValidatePostSize`
- Added `MVPS\Lumis\Framework\Http\Exceptions\AccessDeniedException`
- Added `MVPS\Lumis\Framework\Http\Exceptions\ConflictException`
- Added `MVPS\Lumis\Framework\Http\Exceptions\ContentTooLargeException`
- Added `MVPS\Lumis\Framework\Http\Exceptions\GoneException`
- Added `MVPS\Lumis\Framework\Http\Exceptions\LengthRequiredException`
- Added `MVPS\Lumis\Framework\Http\Exceptions\LockedException`
- Added `MVPS\Lumis\Framework\Http\Exceptions\NotAcceptableException`
- Added `MVPS\Lumis\Framework\Http\Exceptions\PreconditionFailedException`
- Added `MVPS\Lumis\Framework\Http\Exceptions\PreconditionRequiredException`
- Added `MVPS\Lumis\Framework\Http\Exceptions\ServiceUnavailableException`
- Added `MVPS\Lumis\Framework\Http\Exceptions\TooManyRequestsException`
- Added `MVPS\Lumis\Framework\Http\Exceptions\UnprocessableEntityException`
- Added `MVPS\Lumis\Framework\Http\Exceptions\UnsupportedMediaTypeException`
- Updated `MVPS\Lumis\Framework\Http\Exceptions\BadRequestHttpException` class name to `BadRequestException`
- Updated `MVPS\Lumis\Framework\Http\Exceptions\MethodNotAllowedHttpException` class name to `MethodNotAllowedException`
- Updated `MVPS\Lumis\Framework\Http\Exceptions\NotFoundHttpException` class name to `NotFoundException`
- Added `fromStatusCode` method to `MVPS\Lumis\Framework\Http\Exceptions\HttpException`
- Added `MVPS\Lumis\Framework\Http\Traits\CanBePrecognitive`
- Added `MVPS\Lumis\Framework\Http\Traits\FileHelpers`
- Added `MVPS\Lumis\Framework\Http\UploadedFile`
- Updated `MVPS\Lumis\Framework\Http\Traits\InteractsWithRequestInput`:
	- Added `Illuminate\Support\Traits\Dumpable` trait usage
	- Renamed `collection` method to `collect`
	- Added methods:
		- `all`
		- `allFiles`
		- `bearerToken`
		- `convertUploadedFiles`
		- `cookie`
		- `dump`
		- `enum`
		- `exists`
		- `file`
		- `float`
		- `hasCookie`
		- `hasFile`
		- `integer`
		- `isValidFile`
		- `keys`
		- `post`
		- `server`
		- `retrieveItem`
- Updated `MVPS\Lumis\Framework\Http\Traits\ResponseTrait`:
	- Added methods:
		- `content`
		- `cookie`
		- `getCallback`
		- `header`
		- `throwResponse`
		- `withCookie`
		- `withHeaders`
		- `withoutCookie`
- Updated `MVPS\Lumis\Framework\Http\Response`:
	- Added properties:
		- `headerBag`
	- Added methods:
		- `__construct`
- Added `MVPS\Lumis\Framework\Routing\PrecognitionCallableDispatcher`
- Added `MVPS\Lumis\Framework\Routing\PrecognitionControllerDispatcher`
- Added `MVPS\Lumis\Framework\Contracts\Filesystem\Factory`
- Added `MVPS\Lumis\Framework\Contracts\Filesystem\Filesystem`
- Added `MVPS\Lumis\Framework\Filesystem\FilesystemManager`
- Updated `MVPS\Lumis\Framework\Filesystem\FilesystemServiceProvider`:
	- Added methods:
		- `getDefaultDriver`
		- `registerDrivers`
		- `registerManager`
- Updated `MVPS\Lumis\Framework\Application`:
	- Updated `VERSION` constant to latest `2.6.0`
	- Added container core aliases:
		- `filesystem`
		- `filesystem.disk`
	- Added methods:
		- `abort`
- Added helper functions:
	- `abort`
	- `join_paths`
	- `precognitive`