### PR TITLE
Release/2.7.0

### DIFF
--- a/src/Framework/Application.php
+++ b/src/Framework/Application.php
@@ -947,6 +947,10 @@ class Application extends Container implements ApplicationContract, CachesConfig
 				\MVPS\Lumis\Framework\Contracts\Routing\Registrar::class,
 				\MVPS\Lumis\Framework\Contracts\Routing\BindingRegistrar::class,
 			],
+			'session.store' => [
+				\MVPS\Lumis\Framework\Session\Store::class,
+				\MVPS\Lumis\Framework\Contracts\Session\Session::class,
+			],
 			'url' => [
 				\MVPS\Lumis\Framework\Routing\UrlGenerator::class,
 				\MVPS\Lumis\Framework\Contracts\Routing\UrlGenerator::class,

--- a/src/Framework/Application.php
+++ b/src/Framework/Application.php
@@ -943,6 +943,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
 				\MVPS\Lumis\Framework\Log\LogService::class,
 				\Psr\Log\LoggerInterface::class,
 			],
+			'redirect' => [\MVPS\Lumis\Framework\Routing\Redirector::class],
 			'request' => [
 				Request::class,
 				\Psr\Http\Message\ServerRequestInterface::class,

--- a/src/Framework/Application.php
+++ b/src/Framework/Application.php
@@ -914,6 +914,11 @@ class Application extends Container implements ApplicationContract, CachesConfig
 				\MVPS\Lumis\Framework\Configuration\Repository::class,
 				\MVPS\Lumis\Framework\Contracts\Configuration\Repository::class,
 			],
+			'cookie' => [
+				\MVPS\Lumis\Framework\Cookie\CookieJar::class,
+				\MVPS\Lumis\Framework\Contracts\Cookie\Factory::class,
+				\MVPS\Lumis\Framework\Contracts\Cookie\QueueingFactory::class,
+			],
 			'db' => [
 				\MVPS\Lumis\Framework\Database\DatabaseManager::class,
 				\Illuminate\Database\ConnectionResolverInterface::class,

--- a/src/Framework/Application.php
+++ b/src/Framework/Application.php
@@ -928,6 +928,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
 				\Illuminate\Database\ConnectionInterface::class,
 			],
 			'db.schema' => [\Illuminate\Database\Schema\Builder::class],
+			// 'encrypter' => [Encrypter::class],
 			'events' => [
 				\MVPS\Lumis\Framework\Events\Dispatcher::class,
 				\MVPS\Lumis\Framework\Contracts\Events\Dispatcher::class,
@@ -961,8 +962,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
 				\MVPS\Lumis\Framework\Routing\UrlGenerator::class,
 				\MVPS\Lumis\Framework\Contracts\Routing\UrlGenerator::class,
 			],
-			// TODO: Implement these
-			// 'encrypter' => [Encrypter::class],
+			// 'validator' => [Validation\Factory::class, Contracts\Validation\Factory::class],
 			'view' => [
 				\MVPS\Lumis\Framework\View\Factory::class,
 				\MVPS\Lumis\Framework\Contracts\View\Factory::class,

--- a/src/Framework/Configuration/Middleware.php
+++ b/src/Framework/Configuration/Middleware.php
@@ -5,6 +5,7 @@ namespace MVPS\Lumis\Framework\Configuration;
 use Closure;
 use MVPS\Lumis\Framework\Http\Middleware\ConvertEmptyStringsToNull;
 use MVPS\Lumis\Framework\Http\Middleware\HandlePrecognitiveRequests;
+use MVPS\Lumis\Framework\Http\Middleware\SetCacheHeaders;
 use MVPS\Lumis\Framework\Http\Middleware\TrimStrings;
 use MVPS\Lumis\Framework\Http\Middleware\TrustHosts;
 use MVPS\Lumis\Framework\Http\Middleware\TrustProxies;
@@ -206,7 +207,7 @@ class Middleware
 			// 'auth' => Authenticate::class,
 			// 'auth.basic' => AuthenticateWithBasicAuth::class,
 			// 'auth.session' => AuthenticateSession::class,
-			// 'cache.headers' => SetCacheHeaders::class,
+			'cache.headers' => SetCacheHeaders::class,
 			// 'can' => Authorize::class,
 			// 'guest' => RedirectIfAuthenticated::class,
 			// 'password.confirm' => RequirePassword::class,

--- a/src/Framework/Contracts/Cookie/Factory.php
+++ b/src/Framework/Contracts/Cookie/Factory.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Contracts\Cookie;
+
+use Symfony\Component\HttpFoundation\Cookie;
+
+interface Factory
+{
+	/**
+	 * Create a cookie that lasts "forever" (five years).
+	 */
+	public function forever(
+		string $name,
+		string|null $value = null,
+		string|null $path = null,
+		string|null $domain = null,
+		bool|null $secure = null,
+		bool $httpOnly = true,
+		bool $raw = false,
+		string|null $sameSite = null
+	): Cookie;
+
+	/**
+	 * Expire the given cookie.
+	 */
+	public function forget(string $name, string|null $path = null, string|null $domain = null): Cookie;
+
+	/**
+	 * Create a new cookie instance.
+	 */
+	public function make(
+		string $name,
+		string|null $value = null,
+		int $minutes = 0,
+		string|null $path = null,
+		string|null $domain = null,
+		bool|null $secure = null,
+		bool $httpOnly = true,
+		bool $raw = false,
+		string|null $sameSite = null
+	): Cookie;
+}

--- a/src/Framework/Contracts/Cookie/QueueingFactory.php
+++ b/src/Framework/Contracts/Cookie/QueueingFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Contracts\Cookie;
+
+interface QueueingFactory extends Factory
+{
+	/**
+	 * Get the cookies which have been queued for the next request.
+	 */
+	public function getQueuedCookies(): array;
+
+	/**
+	 * Queue a cookie to send with the next response.
+	 */
+	public function queue(mixed ...$parameters): void;
+
+	/**
+	 * Remove a cookie from the queue.
+
+	 */
+	public function unqueue(string $name, string|null $path = null): void;
+}

--- a/src/Framework/Contracts/Routing/Registrar.php
+++ b/src/Framework/Contracts/Routing/Registrar.php
@@ -59,8 +59,6 @@ interface Registrar
 
 	/**
 	 * Substitute the implicit Eloquent model bindings for the route.
-	 *
-	 * @return mixed|void
 	 */
-	public function substituteImplicitBindings(Route $route);
+	public function substituteImplicitBindings(Route $route): mixed;
 }

--- a/src/Framework/Contracts/Routing/ResponseFactory.php
+++ b/src/Framework/Contracts/Routing/ResponseFactory.php
@@ -2,25 +2,27 @@
 
 namespace MVPS\Lumis\Framework\Contracts\Routing;
 
+use MVPS\Lumis\Framework\Http\BinaryFileResponse;
 use MVPS\Lumis\Framework\Http\JsonResponse;
 use MVPS\Lumis\Framework\Http\Response;
+use SplFileInfo;
 
 interface ResponseFactory
 {
 	/**
 	 * Create a new file download response.
 	 */
-	// public function download(
-	// 	SplFileInfo|string $file,
-	// 	string|null $name = null,
-	// 	array $headers = [],
-	// 	string|null $disposition = 'attachment'
-	// ): BinaryFileResponse;
+	public function download(
+		SplFileInfo|string $file,
+		string|null $name = null,
+		array $headers = [],
+		string|null $disposition = 'attachment'
+	): BinaryFileResponse;
 
 	/**
 	 * Return the raw contents of a binary file.
 	 */
-	// public function file(SplFileInfo|string $file, array $headers = []): BinaryFileResponse;
+	public function file(SplFileInfo|string $file, array $headers = []): BinaryFileResponse;
 
 	/**
 	 * Create a new JSON response instance.

--- a/src/Framework/Contracts/Routing/ResponseFactory.php
+++ b/src/Framework/Contracts/Routing/ResponseFactory.php
@@ -5,6 +5,7 @@ namespace MVPS\Lumis\Framework\Contracts\Routing;
 use MVPS\Lumis\Framework\Http\BinaryFileResponse;
 use MVPS\Lumis\Framework\Http\JsonResponse;
 use MVPS\Lumis\Framework\Http\Response;
+use MVPS\Lumis\Framework\Http\StreamedResponse;
 use SplFileInfo;
 
 interface ResponseFactory
@@ -103,17 +104,17 @@ interface ResponseFactory
 	/**
 	 * Create a new streamed response instance.
 	 */
-	// public function stream(callable $callback, int $status = 200, array $headers = []): StreamedResponse;
+	public function stream(callable $callback, int $status = 200, array $headers = []): StreamedResponse;
 
 	/**
 	 * Create a new streamed response instance as a file download.
 	 */
-	// public function streamDownload(
-	// 	callable $callback,
-	// 	string|null $name = null,
-	// 	array $headers = [],
-	// 	string|null $disposition = 'attachment'
-	// ): StreamedResponse;
+	public function streamDownload(
+		callable $callback,
+		string|null $name = null,
+		array $headers = [],
+		string|null $disposition = 'attachment'
+	): StreamedResponse;
 
 	/**
 	 * Create a new response for a given view.

--- a/src/Framework/Contracts/Routing/ResponseFactory.php
+++ b/src/Framework/Contracts/Routing/ResponseFactory.php
@@ -4,6 +4,7 @@ namespace MVPS\Lumis\Framework\Contracts\Routing;
 
 use MVPS\Lumis\Framework\Http\BinaryFileResponse;
 use MVPS\Lumis\Framework\Http\JsonResponse;
+use MVPS\Lumis\Framework\Http\RedirectResponse;
 use MVPS\Lumis\Framework\Http\Response;
 use MVPS\Lumis\Framework\Http\StreamedResponse;
 use SplFileInfo;
@@ -52,54 +53,55 @@ interface ResponseFactory
 	public function noContent(int $status = 204, array $headers = []): Response;
 
 	/**
-	 * Create a new redirect response, while putting the current URL in the session.
+	 * Create a new redirect response, while putting the
+	 * current URLin the session.
 	 */
-	// public function redirectGuest(
-	// 	string $path,
-	// 	int $status = 302,
-	// 	array $headers = [],
-	// 	bool|null $secure = null
-	// ): RedirectResponse;
+	public function redirectGuest(
+		string $path,
+		int $status = 302,
+		array $headers = [],
+		bool|null $secure = null
+	): RedirectResponse;
 
 	/**
 	 * Create a new redirect response to the given path.
 	 */
-	// public function redirectTo(
-	// 	string $path,
-	// 	int $status = 302,
-	// 	array $headers = [],
-	// 	bool|null $secure = null
-	// ): RedirectResponse;
+	public function redirectTo(
+		string $path,
+		int $status = 302,
+		array $headers = [],
+		bool|null $secure = null
+	): RedirectResponse;
 
 	/**
 	 * Create a new redirect response to a controller action.
 	 */
-	// public function redirectToAction(
-	// 	array|string $action,
-	// 	mixed $parameters = [],
-	// 	int $status = 302,
-	// 	array $headers = []
-	// ): RedirectResponse;
+	public function redirectToAction(
+		array|string $action,
+		mixed $parameters = [],
+		int $status = 302,
+		array $headers = []
+	): RedirectResponse;
 
 	/**
 	 * Create a new redirect response to the previously intended location.
 	 */
-	// public function redirectToIntended(
-	// 	string $default = '/',
-	// 	int $status = 302,
-	// 	array $headers = [],
-	// 	bool|null $secure = null
-	// ): RedirectResponse;
+	public function redirectToIntended(
+		string $default = '/',
+		int $status = 302,
+		array $headers = [],
+		bool|null $secure = null
+	): RedirectResponse;
 
 	/**
 	 * Create a new redirect response to a named route.
 	 */
-	// public function redirectToRoute(
-	// 	string $route,
-	// 	mixed $parameters = [],
-	// 	int $status = 302,
-	// 	array $headers = []
-	// ): RedirectResponse;
+	public function redirectToRoute(
+		string $route,
+		mixed $parameters = [],
+		int $status = 302,
+		array $headers = []
+	): RedirectResponse;
 
 	/**
 	 * Create a new streamed response instance.

--- a/src/Framework/Contracts/Routing/ResponseFactory.php
+++ b/src/Framework/Contracts/Routing/ResponseFactory.php
@@ -2,6 +2,7 @@
 
 namespace MVPS\Lumis\Framework\Contracts\Routing;
 
+use MVPS\Lumis\Framework\Http\JsonResponse;
 use MVPS\Lumis\Framework\Http\Response;
 
 interface ResponseFactory
@@ -24,18 +25,18 @@ interface ResponseFactory
 	/**
 	 * Create a new JSON response instance.
 	 */
-	// public function json(mixed $data = [], int $status = 200, array $headers = [], int $options = 0): JsonResponse;
+	public function json(mixed $data = [], int $status = 200, array $headers = [], int $options = 0): JsonResponse;
 
 	/**
 	 * Create a new JSONP response instance.
 	 */
-	// public function jsonp(
-	// 	string $callback,
-	// 	mixed $data = [],
-	// 	int $status = 200,
-	// 	array $headers = [],
-	// 	int $options = 0
-	// ): JsonResponse;
+	public function jsonp(
+		string $callback,
+		mixed $data = [],
+		int $status = 200,
+		array $headers = [],
+		int $options = 0
+	): JsonResponse;
 
 	/**
 	 * Create a new response instance.

--- a/src/Framework/Contracts/Routing/UrlGenerator.php
+++ b/src/Framework/Contracts/Routing/UrlGenerator.php
@@ -28,6 +28,11 @@ interface UrlGenerator
 	public function getRootControllerNamespace(): string;
 
 	/**
+	 * Get the URL for the previous request.
+	 */
+	public function previous(mixed $fallback = false): string;
+
+	/**
 	 * Get the URL to a named route.
 	 *
 	 * @throws \InvalidArgumentException

--- a/src/Framework/Contracts/Session/ExistenceAware.php
+++ b/src/Framework/Contracts/Session/ExistenceAware.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Contracts\Session;
+
+use SessionHandlerInterface;
+
+interface ExistenceAware
+{
+	/**
+	 * Set the existence state for the session.
+	 */
+	public function setExists(bool $value): SessionHandlerInterface;
+}

--- a/src/Framework/Contracts/Session/Session.php
+++ b/src/Framework/Contracts/Session/Session.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Contracts\Session;
+
+use MVPS\Lumis\Framework\Http\Request;
+use SessionHandlerInterface;
+
+interface Session
+{
+	/**
+	 * Get all of the session data.
+	 */
+	public function all(): array;
+
+	/**
+	 * Checks if a key exists.
+	 */
+	public function exists(string|array $key): bool;
+
+	/**
+	 * Remove all of the items from the session.
+	 */
+	public function flush(): void;
+
+	/**
+	 * Remove one or many items from the session.
+	 */
+	public function forget(string|array $keys): void;
+
+	/**
+	 * Get an item from the session.
+	 */
+	public function get(string $key, mixed $default = null): mixed;
+
+	/**
+	 * Get the session handler instance.
+	 */
+	public function getHandler(): SessionHandlerInterface;
+
+	/**
+	 * Get the current session ID.
+	 */
+	public function getId(): string;
+
+	/**
+	 * Get the name of the session.
+	 */
+	public function getName(): string;
+
+	/**
+	 * Determine if the session handler needs a request.
+	 */
+	public function handlerNeedsRequest(): bool;
+
+	/**
+	 * Checks if a key is present and not null.
+	 */
+	public function has(string|array $key): bool;
+
+	/**
+	 * Flush the session data and regenerate the ID.
+	 */
+	public function invalidate(): bool;
+
+	/**
+	 * Determine if the session has been started.
+	 */
+	public function isStarted(): bool;
+
+	/**
+	 * Generate a new session ID for the session.
+	 */
+	public function migrate(bool $destroy = false): bool;
+
+	/**
+	 * Get the previous URL from the session.
+	 */
+	public function previousUrl(): string|null;
+
+	/**
+	 * Get the value of a given key and then forget it.
+	 */
+	public function pull(string $key, mixed $default = null): mixed;
+
+	/**
+	 * Put a key / value pair or array of key / value pairs in the session.
+	 */
+	public function put(string|array $key, mixed $value = null): void;
+
+	/**
+	 * Generate a new session identifier.
+	 */
+	public function regenerate(bool $destroy = false): bool;
+
+	/**
+	 * Regenerate the CSRF token value.
+	 */
+	public function regenerateToken(): void;
+
+	/**
+	 * Remove an item from the session, returning its value.
+	 */
+	public function remove(string $key): mixed;
+
+	/**
+	 * Save the session data to storage.
+	 */
+	public function save(): void;
+
+	/**
+	 * Set the session ID.
+	 */
+	public function setId(string $id): void;
+
+	/**
+	 * Set the name of the session.
+	 */
+	public function setName(string $name): void;
+
+	/**
+	 * Set the "previous" URL in the session.
+	 */
+	public function setPreviousUrl(string $url): void;
+
+	/**
+	 * Set the request on the handler instance.
+	 */
+	public function setRequestOnHandler(Request $request): void;
+
+	/**
+	 * Start the session, reading the data from a handler.
+	 */
+	public function start(): bool;
+
+	/**
+	 * Get the CSRF token value.
+	 */
+	public function token(): string;
+}

--- a/src/Framework/Cookie/CookieJar.php
+++ b/src/Framework/Cookie/CookieJar.php
@@ -1,0 +1,208 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Cookie;
+
+use Illuminate\Support\InteractsWithTime;
+use Illuminate\Support\Traits\Macroable;
+use MVPS\Lumis\Framework\Contracts\Cookie\QueueingFactory as CookieJarContract;
+use MVPS\Lumis\Framework\Support\Arr;
+use Symfony\Component\HttpFoundation\Cookie;
+
+class CookieJar implements CookieJarContract
+{
+	use InteractsWithTime;
+	use Macroable;
+
+	/**
+	 * The default domain (if specified).
+	 *
+	 * @var string|null
+	 */
+	protected string|null $domain = null;
+
+	/**
+	 * The default path (if specified).
+	 *
+	 * @var string
+	 */
+	protected string $path = '/';
+
+	/**
+	 * All of the cookies queued for sending.
+	 *
+	 * @var array<\Symfony\Component\HttpFoundation\Cookie>
+	 */
+	protected array $queued = [];
+
+	/**
+	 * The default SameSite option (defaults to lax).
+	 *
+	 * @var string
+	 */
+	protected string $sameSite = 'lax';
+
+	/**
+	 * The default secure setting (defaults to null).
+	 *
+	 * @var bool|null
+	 */
+	protected bool|null $secure = null;
+
+	/**
+	 * Queue a cookie to expire with the next response.
+	 */
+	public function expire(string $name, string|null $path = null, string|null $domain = null): void
+	{
+		$this->queue($this->forget($name, $path, $domain));
+	}
+
+	/**
+	 * Flush the cookies which have been queued for the next request.
+	 */
+	public function flushQueuedCookies(): static
+	{
+		$this->queued = [];
+
+		return $this;
+	}
+
+	/**
+	 * Create a cookie that lasts "forever" (five years).
+	 */
+	public function forever(
+		string $name,
+		string|null $value = null,
+		string|null $path = null,
+		string|null $domain = null,
+		bool|null $secure = null,
+		bool $httpOnly = true,
+		bool $raw = false,
+		string|null $sameSite = null
+	): Cookie {
+		return $this->make($name, $value, 576000, $path, $domain, $secure, $httpOnly, $raw, $sameSite);
+	}
+
+	/**
+	 * Expire the given cookie.
+	 */
+	public function forget(string $name, string|null $path = null, string|null $domain = null): Cookie
+	{
+		return $this->make($name, null, -2628000, $path, $domain);
+	}
+
+	/**
+	 * Get the path and domain, or the default values.
+	 */
+	protected function getPathAndDomain(
+		string $path,
+		string|null $domain,
+		bool|null $secure = null,
+		string|null $sameSite = null
+	): array {
+		return [
+			$path ?: $this->path,
+			$domain ?: $this->domain,
+			is_bool($secure) ? $secure : $this->secure,
+			$sameSite ?: $this->sameSite,
+		];
+	}
+
+	/**
+	 * Get the cookies which have been queued for the next request.
+	 */
+	public function getQueuedCookies(): array
+	{
+		return Arr::flatten($this->queued);
+	}
+
+	/**
+	 * Determine if a cookie has been queued.
+	 */
+	public function hasQueued(string $key, string|null $path = null): bool
+	{
+		return ! is_null($this->queued($key, null, $path));
+	}
+
+	/**
+	 * Create a new cookie instance.
+	 */
+	public function make(
+		string $name,
+		string|null $value = null,
+		int $minutes = 0,
+		string|null $path = null,
+		string|null $domain = null,
+		bool|null $secure = null,
+		bool $httpOnly = true,
+		bool $raw = false,
+		string|null $sameSite = null
+	): Cookie {
+		[$path, $domain, $secure, $sameSite] = $this->getPathAndDomain($path, $domain, $secure, $sameSite);
+
+		$time = ($minutes === 0) ? 0 : $this->availableAt($minutes * 60);
+
+		return new Cookie($name, $value, $time, $path, $domain, $secure, $httpOnly, $raw, $sameSite);
+	}
+
+	/**
+	 * Queue a cookie to send with the next response.
+	 */
+	public function queue(mixed ...$parameters): void
+	{
+		$cookie = isset($parameters[0]) && $parameters[0] instanceof Cookie
+			? $cookie = $parameters[0]
+			: $this->make(...array_values($parameters));
+
+		if (! isset($this->queued[$cookie->getName()])) {
+			$this->queued[$cookie->getName()] = [];
+		}
+
+		$this->queued[$cookie->getName()][$cookie->getPath()] = $cookie;
+	}
+
+	/**
+	 * Get a queued cookie instance.
+	 */
+	public function queued(string $key, mixed $default = null, string|null $path = null): Cookie|null
+	{
+		$queued = Arr::get($this->queued, $key, $default);
+
+		if (is_null($path)) {
+			return Arr::last($queued, null, $default);
+		}
+
+		return Arr::get($queued, $path, $default);
+	}
+
+	/**
+	 * Set the default path and domain for the jar.
+	 */
+	public function setDefaultPathAndDomain(
+		string $path,
+		string|null $domain = null,
+		bool|null $secure = false,
+		string|null $sameSite = null
+	): static {
+		[$this->path, $this->domain, $this->secure, $this->sameSite] = [$path, $domain, $secure, $sameSite];
+
+		return $this;
+	}
+
+	/**
+	 * Remove a cookie from the queue.
+	 */
+	public function unqueue(string $name, string|null $path = null): void
+	{
+		if ($path === null) {
+			unset($this->queued[$name]);
+
+			return;
+		}
+
+		unset($this->queued[$name][$path]);
+
+		if (empty($this->queued[$name])) {
+			unset($this->queued[$name]);
+		}
+	}
+}

--- a/src/Framework/Cookie/CookieServiceProvider.php
+++ b/src/Framework/Cookie/CookieServiceProvider.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Cookie;
+
+use MVPS\Lumis\Framework\Providers\ServiceProvider;
+
+class CookieServiceProvider extends ServiceProvider
+{
+	/**
+	 * Register the service provider.
+	 */
+	public function register(): void
+	{
+		$this->app->singleton('cookie', function ($app) {
+			$config = $app->make('config')->get('session');
+
+			return (new CookieJar)->setDefaultPathAndDomain(
+				$config['path'],
+				$config['domain'],
+				$config['secure'],
+				$config['same_site'] ?? null
+			);
+		});
+	}
+}

--- a/src/Framework/Http/BinaryFileResponse.php
+++ b/src/Framework/Http/BinaryFileResponse.php
@@ -66,7 +66,7 @@ class BinaryFileResponse extends Response
 	protected static bool $trustXSendfileTypeHeader = false;
 
 	/**
-	 * Create a new binary file response instance.
+	 * Create a new binary file HTTP response instance.
 	 *
 	 * Constructs a response representing a file resource, setting default
 	 * headers and options.

--- a/src/Framework/Http/BinaryFileResponse.php
+++ b/src/Framework/Http/BinaryFileResponse.php
@@ -136,6 +136,9 @@ class BinaryFileResponse extends Response
 		return $lastModified->format('D, d M Y H:i:s') . ' GMT' === $header;
 	}
 
+	/**
+	 * Prepares the file download response.
+	 */
 	public function prepare(Request $request): static
 	{
 		if ($this->isInformational() || $this->isEmpty()) {

--- a/src/Framework/Http/BinaryFileResponse.php
+++ b/src/Framework/Http/BinaryFileResponse.php
@@ -4,12 +4,12 @@ namespace MVPS\Lumis\Framework\Http;
 
 use DateTimeImmutable;
 use LogicException;
+use MVPS\Lumis\Framework\Http\File;
 use MVPS\Lumis\Framework\Http\Request;
 use SplFileInfo;
 use SplFileObject;
 use SplTempFileObject;
 use Symfony\Component\HttpFoundation\File\Exception\FileException;
-use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\HttpFoundation\HeaderUtils;
 
 class BinaryFileResponse extends Response
@@ -31,7 +31,7 @@ class BinaryFileResponse extends Response
 	/**
 	 * The file instance representing the response content.
 	 *
-	 * @var \Symfony\Component\HttpFoundation\File\File
+	 * @var \MVPS\Lumis\Framework\Http\File
 	 */
 	protected File $file;
 

--- a/src/Framework/Http/BinaryFileResponse.php
+++ b/src/Framework/Http/BinaryFileResponse.php
@@ -1,0 +1,464 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Http;
+
+use DateTimeImmutable;
+use LogicException;
+use MVPS\Lumis\Framework\Http\Request;
+use SplFileInfo;
+use SplFileObject;
+use SplTempFileObject;
+use Symfony\Component\HttpFoundation\File\Exception\FileException;
+use Symfony\Component\HttpFoundation\File\File;
+use Symfony\Component\HttpFoundation\HeaderUtils;
+
+class BinaryFileResponse extends Response
+{
+	/**
+	 * The size of each chunk to read from the file.
+	 *
+	 * @var int
+	 */
+	protected int $chunkSize = 16 * 1024;
+
+	/**
+	 * Indicates whether to delete the file after sending the content.
+	 *
+	 * @var bool
+	 */
+	protected bool $deleteFileAfterSend = false;
+
+	/**
+	 * The file instance representing the response content.
+	 *
+	 * @var \Symfony\Component\HttpFoundation\File\File
+	 */
+	protected File $file;
+
+	/**
+	 * The maximum number of bytes to read from the file.
+	 *
+	 * A negative value indicates no limit.
+	 *
+	 * @var int
+	 */
+	protected int $maxlen = -1;
+
+	/**
+	 * The starting offset for reading the file.
+	 *
+	 * @var int
+	 */
+	protected int $offset = 0;
+
+	/**
+	 * Temporary file object used for handling large file uploads.
+	 *
+	 * @var \SplTempFileObject|null
+	 */
+	protected SplTempFileObject|null $tempFileObject = null;
+
+	/**
+	 * Indicates whether to trust the X-Sendfile header.
+	 *
+	 * @var bool
+	 */
+	protected static bool $trustXSendfileTypeHeader = false;
+
+	/**
+	 * Create a new binary file response instance.
+	 *
+	 * Constructs a response representing a file resource, setting default
+	 * headers and options.
+	 */
+	public function __construct(
+		SplFileInfo|string $file,
+		int $status = 200,
+		array $headers = [],
+		bool $public = true,
+		string|null $contentDisposition = null,
+		bool $autoEtag = false,
+		bool $autoLastModified = true
+	) {
+		parent::__construct(null, $status, $headers);
+
+		$this->setFile($file, $contentDisposition, $autoEtag, $autoLastModified);
+
+		if ($public) {
+			$this->setPublic();
+		}
+	}
+
+	/**
+	 * Configures whether to delete the file after sending the response.
+	 *
+	 * If set to true, the file will be deleted once the response is sent.
+	 * This behavior is overridden if the `X-Sendfile` header is used.
+	 */
+	public function deleteFileAfterSend(bool $shouldDelete = true): static
+	{
+		$this->deleteFileAfterSend = $shouldDelete;
+
+		return $this;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getContent(): string|false
+	{
+		return false;
+	}
+
+	/**
+	 * Retrieves the file instance associated with the response.
+	 */
+	public function getFile(): File
+	{
+		return $this->file;
+	}
+
+	/**
+	 * Checks if the provided If-Range header is valid.
+	 */
+	protected function hasValidIfRangeHeader(string|null $header): bool
+	{
+		if ($this->getEtag() === $header) {
+			return true;
+		}
+
+		$lastModified = $this->getLastModified();
+
+		if (is_null($lastModified)) {
+			return false;
+		}
+
+		return $lastModified->format('D, d M Y H:i:s') . ' GMT' === $header;
+	}
+
+	public function prepare(Request $request): static
+	{
+		if ($this->isInformational() || $this->isEmpty()) {
+			parent::prepare($request);
+
+			$this->maxlen = 0;
+
+			return $this;
+		}
+
+		if (! $this->headerBag->has('Content-Type')) {
+			$this->headerBag->set(
+				'Content-Type',
+				$this->file->getMimeType() ?: 'application/octet-stream'
+			);
+		}
+
+		parent::prepare($request);
+
+		$this->offset = 0;
+		$this->maxlen = -1;
+
+		$fileSize = $this->file->getSize();
+
+		if ($fileSize === false) {
+			return $this;
+		}
+
+		$this->headerBag->remove('Transfer-Encoding');
+
+		$this->headerBag->set('Content-Length', $fileSize);
+
+		// Set the Accept-Ranges header based on the request method.
+		if (! $this->headerBag->has('Accept-Ranges')) {
+			// For safe HTTP methods, allow byte ranges; otherwise, disable them.
+			$this->headerBag->set('Accept-Ranges', $request->isMethodSafe() ? 'bytes' : 'none');
+		}
+
+		if (static::$trustXSendfileTypeHeader && $request->headerBag->has('X-Sendfile-Type')) {
+			// If the X-Sendfile header is present, use it to send the file directly.
+			$type = $request->headerBag->get('X-Sendfile-Type');
+			$path = $this->file->getRealPath();
+
+			// Fallback to using the file path if real path is not available.
+			if ($path === false) {
+				$path = $this->file->getPathname();
+			}
+
+			if (strtolower($type) === 'x-accel-redirect') {
+				// Process X-Accel-Mapping header substitutions based on the
+				// X-Accel-Mapping header value, which is typically used by
+				// Nginx to configure content acceleration.
+				// @link https://www.nginx.com/resources/wiki/start/topics/examples/x-accel/#x-accel-redirect
+				$parts = HeaderUtils::split($request->headerBag->get('X-Accel-Mapping', ''), ',=');
+
+				foreach ($parts as $part) {
+					[$pathPrefix, $location] = $part;
+
+					// Set X-Accel-Redirect header only if a valid URI can be
+					// generated, as nginx cannot serve arbitrary file paths.
+					if (str_starts_with($path, $pathPrefix)) {
+						$path = $location . substr($path, strlen($pathPrefix));
+
+						$this->headerBag->set($type, $path);
+						$this->maxlen = 0;
+
+						break;
+					}
+				}
+			} else {
+				$this->headerBag->set($type, $path);
+				$this->maxlen = 0;
+			}
+		} elseif ($request->headerBag->has('Range') && $request->isMethod('GET')) {
+			if (
+				! $request->headerBag->has('If-Range') ||
+				$this->hasValidIfRangeHeader($request->headerBag->get('If-Range'))
+			) {
+				$range = $request->headerBag->get('Range');
+
+				if (str_starts_with($range, 'bytes=')) {
+					[$start, $end] = explode('-', substr($range, 6), 2) + [1 => 0];
+
+					$end = $end === '' ? $fileSize - 1 : (int) $end;
+
+					if ($start === '') {
+						$start = $fileSize - $end;
+						$end = $fileSize - 1;
+					} else {
+						$start = (int) $start;
+					}
+
+					if ($start <= $end) {
+						$end = min($end, $fileSize - 1);
+
+						if ($start < 0 || $start > $end) {
+							$this->headerBag->set('Content-Range', sprintf('bytes */%s', $fileSize));
+						} elseif ($end - $start < $fileSize - 1) {
+							$this->maxlen = $end < $fileSize ? $end - $start + 1 : -1;
+							$this->offset = $start;
+
+							$this->headerBag->set(
+								'Content-Range',
+								sprintf('bytes %s-%s/%s', $start, $end, $fileSize)
+							);
+
+							$this->headerBag->set('Content-Length', $end - $start + 1);
+						}
+					}
+				}
+			}
+		}
+
+		if ($request->isMethod('HEAD')) {
+			$this->maxlen = 0;
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Sends the file content to the output buffer.
+	 */
+	public function sendContent(): static
+	{
+		try {
+			if (! $this->isSuccessful() || $this->maxlen === 0) {
+				return $this;
+			}
+
+			$output = fopen('php://output', 'w');
+
+			if ($this->tempFileObject) {
+				$file = $this->tempFileObject;
+
+				$file->rewind();
+			} else {
+				$file = new SplFileObject($this->file->getPathname(), 'r');
+			}
+
+			ignore_user_abort(true);
+
+			if ($this->offset !== 0) {
+				$file->fseek($this->offset);
+			}
+
+			$length = $this->maxlen;
+
+			while ($length && ! $file->eof()) {
+				$read = $length > $this->chunkSize || 0 > $length ? $this->chunkSize : $length;
+
+				$data = $file->fread($read);
+
+				if ($data === false) {
+					break;
+				}
+
+				while ($data !== '') {
+					$read = fwrite($output, $data);
+
+					if ($read === false || connection_aborted()) {
+						break 2;
+					}
+
+					if ($length > 0) {
+						$length -= $read;
+					}
+
+					$data = substr($data, $read);
+				}
+			}
+
+			fclose($output);
+		} finally {
+			if (is_null($this->tempFileObject) && $this->deleteFileAfterSend && is_file($this->file->getPathname())) {
+				unlink($this->file->getPathname());
+			}
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Automatically generates and sets the ETag header based on the
+	 * file's content.
+	 */
+	public function setAutoEtag(): static
+	{
+		$this->setEtag(
+			base64_encode(hash_file('xxh128', $this->file->getPathname(), true))
+		);
+
+		return $this;
+	}
+
+	/**
+	 * Sets the Last-Modified header based on the file's modification time.
+	 */
+	public function setAutoLastModified(): static
+	{
+		$this->setLastModified(
+			DateTimeImmutable::createFromFormat('U', $this->file->getMTime())
+		);
+
+		return $this;
+	}
+
+	/**
+	 * Sets the chunk size for streaming the file content.
+	 */
+	public function setChunkSize(int $chunkSize): static
+	{
+		if ($chunkSize < 1 || $chunkSize > PHP_INT_MAX) {
+			throw new LogicException(
+				'Invalid chunk size: must be a positive integer less than or equal to PHP_INT_MAX.'
+			);
+		}
+
+		$this->chunkSize = $chunkSize;
+
+		return $this;
+	}
+
+	/**
+	 * Prevents setting content on a binary file response.
+	 *
+	 * @throws \LogicException
+	 */
+	public function setContent(mixed $content): static
+	{
+		if (! is_null($content)) {
+			throw new LogicException(
+				'Setting content on a BinaryFileResponse is not supported.' .
+				' Use the file property to specify the file to be sent.'
+			);
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Sets the Content-Disposition header for the response.
+	 */
+	public function setContentDisposition(
+		string $disposition,
+		string $filename = '',
+		string $filenameFallback = ''
+	): static {
+		if ($filename === '') {
+			$filename = $this->file->getFilename();
+		}
+
+		if (
+			$filenameFallback === '' &&
+			(! preg_match('/^[\x20-\x7e]*$/', $filename) || str_contains($filename, '%'))
+		) {
+			$encoding = mb_detect_encoding($filename, null, true) ?: '8bit';
+
+			for ($i = 0, $filenameLength = mb_strlen($filename, $encoding); $i < $filenameLength; ++$i) {
+				$char = mb_substr($filename, $i, 1, $encoding);
+
+				if ($char === '%' || ord($char) < 32 || ord($char) > 126) {
+					$filenameFallback .= '_';
+				} else {
+					$filenameFallback .= $char;
+				}
+			}
+		}
+
+		$dispositionHeader = $this->headerBag->makeDisposition($disposition, $filename, $filenameFallback);
+
+		$this->headerBag->set('Content-Disposition', $dispositionHeader);
+
+		return $this;
+	}
+
+	/**
+	 * Sets the file to stream.
+	 *
+	 * @throws \Symfony\Component\HttpFoundation\File\Exception\FileException
+	 */
+	public function setFile(
+		SplFileInfo|string $file,
+		string|null $contentDisposition = null,
+		bool $autoEtag = false,
+		bool $autoLastModified = true
+	): static {
+		$isTemporaryFile = $file instanceof SplTempFileObject;
+
+		$this->tempFileObject = $isTemporaryFile ? $file : null;
+
+		if (! $file instanceof File) {
+			$file = $file instanceof SplFileInfo
+				? new File($file->getPathname(), ! $isTemporaryFile)
+				: new File((string) $file);
+		}
+
+		if (! $file->isReadable() && ! $isTemporaryFile) {
+			throw new FileException('The specified file is not readable: ' . $file->getPathname());
+		}
+
+		$this->file = $file;
+
+		if ($autoEtag) {
+			$this->setAutoEtag();
+		}
+
+		if ($autoLastModified && ! $isTemporaryFile) {
+			$this->setAutoLastModified();
+		}
+
+		if ($contentDisposition) {
+			$this->setContentDisposition($contentDisposition);
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Enables trusting the X-Sendfile-Type header.
+	 */
+	public static function trustXSendfileTypeHeader(): void
+	{
+		self::$trustXSendfileTypeHeader = true;
+	}
+}

--- a/src/Framework/Http/Client/PendingRequest.php
+++ b/src/Framework/Http/Client/PendingRequest.php
@@ -803,25 +803,25 @@ class PendingRequest
 			return [];
 		}
 
-		$laravelData = $options[$this->bodyFormat] ?? $options['query'] ?? [];
+		$lumisData = $options[$this->bodyFormat] ?? $options['query'] ?? [];
 
 		$urlString = Str::of($url);
 
-		if (empty($laravelData) && $method === 'GET' && $urlString->contains('?')) {
-			$laravelData = (string) $urlString->after('?');
+		if (empty($lumisData) && $method === 'GET' && $urlString->contains('?')) {
+			$lumisData = (string) $urlString->after('?');
 		}
 
-		if (is_string($laravelData)) {
-			parse_str($laravelData, $parsedData);
+		if (is_string($lumisData)) {
+			parse_str($lumisData, $parsedData);
 
-			$laravelData = is_array($parsedData) ? $parsedData : [];
+			$lumisData = is_array($parsedData) ? $parsedData : [];
 		}
 
-		if ($laravelData instanceof JsonSerializable) {
-			$laravelData = $laravelData->jsonSerialize();
+		if ($lumisData instanceof JsonSerializable) {
+			$lumisData = $lumisData->jsonSerialize();
 		}
 
-		return is_array($laravelData) ? $laravelData : [];
+		return is_array($lumisData) ? $lumisData : [];
 	}
 
 	/**
@@ -1066,7 +1066,7 @@ class PendingRequest
 	{
 		$clientMethod = $this->async ? 'requestAsync' : 'request';
 
-		$laravelData = $this->parseRequestData($method, $url, $options);
+		$lumisData = $this->parseRequestData($method, $url, $options);
 
 		$onStats = function ($transferStats) {
 			$callback = $this->options['on_stats'] ?? false;
@@ -1079,7 +1079,7 @@ class PendingRequest
 		};
 
 		$mergedOptions = $this->normalizeRequestOptions($this->mergeOptions([
-			'lumis_data' => $laravelData,
+			'lumis_data' => $lumisData,
 			'on_stats' => $onStats,
 		], $options));
 

--- a/src/Framework/Http/File.php
+++ b/src/Framework/Http/File.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Http;
+
+use MVPS\Lumis\Framework\Http\Traits\FileHelpers;
+use Symfony\Component\HttpFoundation\File\File as SymfonyFile;
+
+class File extends SymfonyFile
+{
+	use FileHelpers;
+}

--- a/src/Framework/Http/JsonResponse.php
+++ b/src/Framework/Http/JsonResponse.php
@@ -1,0 +1,250 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Http;
+
+use ArrayObject;
+use InvalidArgumentException;
+use JsonSerializable;
+use MVPS\Lumis\Framework\Contracts\Support\Arrayable;
+use MVPS\Lumis\Framework\Contracts\Support\Jsonable;
+
+class JsonResponse extends Response
+{
+	/**
+	 * Default JSON encoding flags for enhanced security.
+	 *
+	 * Includes escaping of special characters for protection against XSS attacks.
+	 *
+	 * @var int
+	 */
+	public const DEFAULT_ENCODING_OPTIONS = JSON_HEX_TAG
+		| JSON_HEX_APOS
+		| JSON_HEX_AMP
+		| JSON_HEX_QUOT
+		| JSON_UNESCAPED_SLASHES;
+
+	/**
+	 * The callback function for custom JSON encoding.
+	 *
+	 * @var string|null
+	 */
+	protected string|null $callback = null;
+
+	/**
+	 * Encoding options for JSON serialization.
+	 *
+	 * @var int
+	 */
+	protected int $encodingOptions;
+
+	/**
+	* The data to be encoded as JSON.
+	*
+	* Can be an array, object, or scalar value.
+	*
+	* @var mixed
+	*/
+	private mixed $data;
+
+	/**
+	 * Create a new JSON HTTP response instance.
+	 */
+	public function __construct(
+		mixed $data = null,
+		int $status = 200,
+		array $headers = [],
+		int $encodingOptions = 0
+	) {
+		$this->encodingOptions = $encodingOptions;
+
+		parent::__construct('', $status, $headers);
+
+		$this->setData($data ?? new ArrayObject);
+	}
+
+	/**
+	 * Creates a JSON response instance from a JSON string.
+	 */
+	public static function fromJsonString(string|null $data = null, int $status = 200, array $headers = []): static
+	{
+		return new static($data, $status, $headers, 0);
+	}
+
+	/**
+	 * Retrieves the decoded JSON response content.
+	 */
+	public function getData($assoc = false, $depth = 512): mixed
+	{
+		return json_decode($this->data, $assoc, $depth);
+	}
+
+	/**
+	 * Retrieves the JSON encoding options.
+	 */
+	public function getEncodingOptions(): int
+	{
+		return $this->encodingOptions;
+	}
+
+	/**
+	 * Determine if a JSON encoding option is set.
+	 */
+	public function hasEncodingOption(int $option): bool
+	{
+		return (bool) ($this->encodingOptions & $option);
+	}
+
+	/**
+	 * Determine if an error occurred during JSON encoding.
+	 */
+	protected function hasValidJson(int $jsonError): bool
+	{
+		if ($jsonError === JSON_ERROR_NONE) {
+			return true;
+		}
+
+		return $this->hasEncodingOption(JSON_PARTIAL_OUTPUT_ON_ERROR) && in_array($jsonError, [
+			JSON_ERROR_RECURSION,
+			JSON_ERROR_INF_OR_NAN,
+			JSON_ERROR_UNSUPPORTED_TYPE,
+		]);
+	}
+
+	/**
+	 * Sets the JSONP callback.
+	 *
+	 * @throws \InvalidArgumentException
+	 */
+	public function setCallback(string|null $callback): static
+	{
+		if (! is_null($callback)) {
+			$pattern = '/^[$_\p{L}][$_\p{L}\p{Mn}\p{Mc}\p{Nd}\p{Pc}\x{200C}\x{200D}]*(?:\[(?:"(?:\\\.|[^"\\\])*"|\'(?:\\\.|[^\'\\\])*\'|\d+)\])*?$/u';
+
+			$reserved = [
+				'break',
+				'do',
+				'instanceof',
+				'typeof',
+				'case',
+				'else',
+				'new',
+				'var',
+				'catch',
+				'finally',
+				'return',
+				'void',
+				'continue',
+				'for',
+				'switch',
+				'while',
+				'debugger',
+				'function',
+				'this',
+				'with',
+				'default',
+				'if',
+				'throw',
+				'delete',
+				'in',
+				'try',
+				'class',
+				'enum',
+				'extends',
+				'super',
+				 'const',
+				'export',
+				'import',
+				'implements',
+				'let',
+				'private',
+				'public',
+				'yield',
+				'interface',
+				'package',
+				'protected',
+				'static',
+				'null',
+				'true',
+				'false',
+			];
+
+			$parts = explode('.', $callback);
+
+			foreach ($parts as $part) {
+				if (! preg_match($pattern, $part) || in_array($part, $reserved, true)) {
+					throw new InvalidArgumentException('The callback name is not valid.');
+				}
+			}
+		}
+
+		$this->callback = $callback;
+
+		return $this->update();
+	}
+
+	/**
+	 * Sets the data to be encoded as JSON.
+	 */
+	public function setData(mixed $data = []): static
+	{
+		$this->original = $data;
+
+		// Clear json_last_error()
+		json_decode('[]');
+
+		$this->data = match (true) {
+			$data instanceof Jsonable => $data->toJson($this->encodingOptions),
+			$data instanceof JsonSerializable => json_encode($data->jsonSerialize(), $this->encodingOptions),
+			$data instanceof Arrayable => json_encode($data->toArray(), $this->encodingOptions),
+			default => json_encode($data, $this->encodingOptions),
+		};
+
+		if (! $this->hasValidJson(json_last_error())) {
+			throw new InvalidArgumentException(json_last_error_msg());
+		}
+
+		return $this->update();
+	}
+
+	/**
+	 * Sets the JSON encoding options.
+	 */
+	public function setEncodingOptions(int $encodingOptions): static
+	{
+		$this->encodingOptions = $encodingOptions;
+
+		return $this->setData($this->getData());
+	}
+
+	/**
+	 * Prepares the JSON response by setting headers and content.
+	 *
+	 * Determines the appropriate content type and formats the
+	 * response data based on the callback or raw data.
+	 */
+	protected function update(): static
+	{
+		if (! is_null($this->callback)) {
+			// Not using application/javascript for compatibility reasons with older browsers.
+			$this->headerBag->set('Content-Type', 'text/javascript');
+
+			return $this->setContent(sprintf('/**/%s(%s);', $this->callback, $this->data));
+		}
+
+		// Preserve custom Content-Type headers, only set the default
+		// 'application/json' if not already defined.
+		if (! $this->headerBag->has('Content-Type') || $this->headerBag->get('Content-Type') === 'text/javascript') {
+			$this->headerBag->set('Content-Type', 'application/json');
+		}
+
+		return $this->setContent($this->data);
+	}
+
+	/**
+	 * Sets the callback function for JSONP output.
+	 */
+	public function withCallback(string|null $callback = null): static
+	{
+		return $this->setCallback($callback);
+	}
+}

--- a/src/Framework/Http/Middleware/CheckResponseForModifications.php
+++ b/src/Framework/Http/Middleware/CheckResponseForModifications.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Http\Middleware;
+
+use Closure;
+use MVPS\Lumis\Framework\Http\Request;
+use MVPS\Lumis\Framework\Http\Response;
+
+class CheckResponseForModifications
+{
+	/**
+	 * Handle an incoming request.
+	 */
+	public function handle(Request $request, Closure $next): mixed
+	{
+		$response = $next($request);
+
+		if ($response instanceof Response && $response->isNotModified($request)) {
+			$response = $response->withNotModified();
+		}
+
+		return $response;
+	}
+}

--- a/src/Framework/Http/Middleware/SetCacheHeaders.php
+++ b/src/Framework/Http/Middleware/SetCacheHeaders.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Http\Middleware;
+
+use Closure;
+use Illuminate\Support\Carbon;
+use MVPS\Lumis\Framework\Http\BinaryFileResponse;
+use MVPS\Lumis\Framework\Http\Request;
+use MVPS\Lumis\Framework\Http\Response;
+use MVPS\Lumis\Framework\Http\StreamedResponse;
+use MVPS\Lumis\Framework\Support\Str;
+
+class SetCacheHeaders
+{
+	/**
+	 * Add cache related HTTP headers.
+	 *
+	 * @throws \InvalidArgumentException
+	 */
+	public function handle(Request $request, Closure $next, string|array $options = []): Response
+	{
+		$response = $next($request);
+
+		if (
+			! $request->isMethodCacheable() ||
+			(
+				! $response->getContent() &&
+				! $response instanceof BinaryFileResponse &&
+				! $response instanceof StreamedResponse
+			)
+		) {
+			return $response;
+		}
+
+		if (is_string($options)) {
+			$options = $this->parseOptions($options);
+		}
+
+		if (! $response->isSuccessful()) {
+			return $response;
+		}
+
+		if (isset($options['etag']) && $options['etag'] === true) {
+			$options['etag'] = $response->getEtag() ?? md5($response->getContent());
+		}
+
+		if (isset($options['last_modified'])) {
+			if (is_numeric($options['last_modified'])) {
+				$options['last_modified'] = Carbon::createFromTimestamp(
+					$options['last_modified'],
+					date_default_timezone_get()
+				);
+			} else {
+				$options['last_modified'] = Carbon::parse($options['last_modified']);
+			}
+		}
+
+		$response->setCache($options);
+
+		if ($response->isNotModified($request)) {
+			$response = $response->withNotModified();
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Parse the given header options.
+	 */
+	protected function parseOptions(string $options): array
+	{
+		return collection(explode(';', rtrim($options, ';')))
+			->mapWithKeys(function ($option) {
+				$data = explode('=', $option, 2);
+
+				return [$data[0] => $data[1] ?? true];
+			})
+			->all();
+	}
+
+	/**
+	 * Specify the options for the middleware.
+	 */
+	public static function using(array|string $options): string
+	{
+		if (is_string($options)) {
+			return static::class . ':' . $options;
+		}
+
+		return collection($options)
+			->map(function ($value, $key) {
+				if (is_bool($value)) {
+					return $value ? $key : null;
+				}
+
+				return is_int($key) ? $value : "{$key}={$value}";
+			})
+			->filter()
+			->map(fn ($value) => Str::finish($value, ';'))
+			->pipe(fn ($options) => rtrim(static::class . ':' . $options->implode(''), ';'));
+	}
+}

--- a/src/Framework/Http/RedirectResponse.php
+++ b/src/Framework/Http/RedirectResponse.php
@@ -1,0 +1,283 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Http;
+
+use Illuminate\Contracts\Support\MessageProvider;
+use Illuminate\Support\MessageBag;
+use Illuminate\Support\Traits\ForwardsCalls;
+use Illuminate\Support\ViewErrorBag;
+use InvalidArgumentException;
+use MVPS\Lumis\Framework\Session\Store as SessionStore;
+use MVPS\Lumis\Framework\Support\Str;
+use Psr\Http\Message\UriInterface;
+use Symfony\Component\HttpFoundation\File\UploadedFile as SymfonyUploadedFile;
+
+class RedirectResponse extends Response
+{
+	use ForwardsCalls;
+
+	/**
+	 * The request instance.
+	 *
+	 * @var \MVPS\Lumis\Framework\Http\Request
+	 */
+	protected Request|null $request = null;
+
+	/**
+	 * The session store instance.
+	 *
+	 * @var \MVPS\Lumis\Framework\Session\Store
+	 */
+	protected SessionStore $session;
+
+	/**
+	 * The target URL for the redirection.
+	 *
+	 * @var string
+	 */
+	protected string $targetUrl;
+
+	/**
+	 * Create a new redirect HTTP response instance.
+	 */
+	public function __construct(string|UriInterface $url, int $status = 302, array $headers = [])
+	{
+		parent::__construct('', $status, $headers);
+
+		$this->setTargetUrl($url);
+
+		if (! $this->isRedirect()) {
+			throw new InvalidArgumentException(
+				sprintf('Invalid HTTP status code for redirect response: %d', $status, $status)
+			);
+		}
+	}
+
+	/**
+	 * Flash an array of input to the session.
+	 */
+	public function exceptInput(): static
+	{
+		return $this->withInput($this->request->except(func_get_args()));
+	}
+
+	/**
+	 * Get the original response content.
+	 *
+	 * @return null
+	 */
+	public function getOriginalContent()
+	{
+		//
+	}
+
+	/**
+	 * Get the request instance.
+	 */
+	public function getRequest(): Request|null
+	{
+		return $this->request;
+	}
+
+	/**
+	 * Get the session store instance.
+	 */
+	public function getSession(): SessionStore|null
+	{
+		return $this->session;
+	}
+
+	/**
+	 * Retrieves the target URL for the redirection.
+	 */
+	public function getTargetUrl(): string
+	{
+		return $this->targetUrl;
+	}
+
+	/**
+	 * Flash an array of input to the session.
+	 */
+	public function onlyInput(): static
+	{
+		return $this->withInput($this->request->only(func_get_args()));
+	}
+
+	/**
+	 * Parse the given errors into an appropriate value.
+	 */
+	protected function parseErrors(MessageProvider|array|string $provider): MessageBag
+	{
+		if ($provider instanceof MessageProvider) {
+			return $provider->getMessageBag();
+		}
+
+		return new MessageBag((array) $provider);
+	}
+
+	/**
+	 * Remove all uploaded files form the given input array.
+	 */
+	protected function removeFilesFromInput(array $input): array
+	{
+		foreach ($input as $key => $value) {
+			if (is_array($value)) {
+				$input[$key] = $this->removeFilesFromInput($value);
+			}
+
+			if ($value instanceof SymfonyUploadedFile) {
+				unset($input[$key]);
+			}
+		}
+
+		return $input;
+	}
+
+	/**
+	 * Set the request instance.
+	 */
+	public function setRequest(Request $request): static
+	{
+		$this->request = $request;
+
+		return $this;
+	}
+
+	/**
+	 * Set the session store instance.
+	 */
+	public function setSession(SessionStore $session): static
+	{
+		$this->session = $session;
+
+		return $this;
+	}
+
+	/**
+	 * Sets the target URL for the redirection response.
+	 *
+	 * @throws \InvalidArgumentException
+	 */
+	public function setTargetUrl(string|UriInterface $url): static
+	{
+		$targetUrl = (string) $url;
+
+		if ($targetUrl === '') {
+			throw new InvalidArgumentException('Cannot redirect to an empty URL.');
+		}
+
+		$this->targetUrl = $targetUrl;
+
+		$this->setContent(sprintf(
+			'<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="UTF-8" />
+		<meta http-equiv="refresh" content="0;url=\'%1$s\'" />
+		<title>Redirecting to %1$s</title>
+	</head>
+	<body>
+		Redirecting to <a href="%1$s">%1$s</a>.
+	</body>
+</html>',
+			htmlspecialchars($targetUrl, ENT_QUOTES, 'UTF-8')
+		));
+
+		$this->headerBag->set('Location', $targetUrl);
+
+		$this->headerBag->set('Content-Type', 'text/html; charset=utf-8');
+
+		return $this;
+	}
+
+	/**
+	 * Flashes data to the session.
+	 */
+	public function with(string|array $key, mixed $value = null): static
+	{
+		$key = is_array($key) ? $key : [$key => $value];
+
+		foreach ($key as $k => $v) {
+			$this->session->flash($k, $v);
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Add cookies to the response.
+	 */
+	public function withCookies(array $cookies): static
+	{
+		foreach ($cookies as $cookie) {
+			$this->headerBag->setCookie($cookie);
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Flash a container of errors to the session.
+	 */
+	public function withErrors(MessageProvider|array|string $provider, string $key = 'default'): static
+	{
+		$value = $this->parseErrors($provider);
+
+		$errors = $this->session->get('errors', new ViewErrorBag);
+
+		if (! $errors instanceof ViewErrorBag) {
+			$errors = new ViewErrorBag;
+		}
+
+		$this->session->flash('errors', $errors->put($key, $value));
+
+		return $this;
+	}
+
+	/**
+	 * Add a fragment identifier to the URL.
+	 */
+	public function withFragment(string $fragment): static
+	{
+		return $this->withoutFragment()
+			->setTargetUrl($this->getTargetUrl() . '#' . Str::after($fragment, '#'));
+	}
+
+	/**
+	 * Flash an array of input to the session.
+	 */
+	public function withInput(array|null $input = null): static
+	{
+		$this->session->flashInput($this->removeFilesFromInput(
+			! is_null($input) ? $input : $this->request->input()
+		));
+
+		return $this;
+	}
+
+	/**
+	 * Remove any fragment identifier from the response URL.
+	 */
+	public function withoutFragment(): static
+	{
+		return $this->setTargetUrl(Str::before($this->getTargetUrl(), '#'));
+	}
+
+	/**
+	 * Dynamically bind flash data in the session.
+	 *
+	 * @throws \BadMethodCallException
+	 */
+	public function __call(string $method, array $parameters): mixed
+	{
+		if (static::hasMacro($method)) {
+			return $this->macroCall($method, $parameters);
+		}
+
+		if (str_starts_with($method, 'with')) {
+			return $this->with(Str::snake(substr($method, 4)), $parameters[0]);
+		}
+
+		static::throwBadMethodCallException($method);
+	}
+}

--- a/src/Framework/Http/RedirectResponse.php
+++ b/src/Framework/Http/RedirectResponse.php
@@ -63,10 +63,8 @@ class RedirectResponse extends Response
 
 	/**
 	 * Get the original response content.
-	 *
-	 * @return null
 	 */
-	public function getOriginalContent()
+	public function getOriginalContent(): mixed
 	{
 		//
 	}
@@ -266,9 +264,13 @@ class RedirectResponse extends Response
 	/**
 	 * Dynamically bind flash data in the session.
 	 *
+	 * @param  string  $method
+	 * @param  array   $parameters
+	 * @return mixed
+	 *
 	 * @throws \BadMethodCallException
 	 */
-	public function __call(string $method, array $parameters): mixed
+	public function __call($method, $parameters)
 	{
 		if (static::hasMacro($method)) {
 			return $this->macroCall($method, $parameters);

--- a/src/Framework/Http/Request.php
+++ b/src/Framework/Http/Request.php
@@ -147,6 +147,13 @@ class Request extends ServerRequest implements Arrayable, ArrayAccess
 	public FileBag $fileBag;
 
 	/**
+	 * The requested format for the response.
+	 *
+	 * @var string|null
+	 */
+	protected string|null $format = null;
+
+	/**
 	 * The request format MIME types.
 	 *
 	 * @var array
@@ -604,6 +611,19 @@ class Request extends ServerRequest implements Arrayable, ArrayAccess
 	public function getRealMethod(): string
 	{
 		return strtoupper($this->serverBag->get('REQUEST_METHOD', 'GET'));
+	}
+
+	/**
+	 * Determines the requested format for the response.
+	 *
+	 * Prioritizes the explicitly set format, then the '_format' request
+	 * attribute, and finally the default format.
+	 */
+	public function getRequestFormat(string|null $default = 'html'): string|null
+	{
+		$this->format ??= $this->attributeBag->get('_format');
+
+		return $this->format ?? $default;
 	}
 
 	/**
@@ -1167,6 +1187,14 @@ class Request extends ServerRequest implements Arrayable, ArrayAccess
 		$this->jsonBag = $json;
 
 		return $this;
+	}
+
+	/**
+	 * Sets the request format.
+	 */
+	public function setRequestFormat(string|null $format): void
+	{
+		$this->format = $format;
 	}
 
 	/**

--- a/src/Framework/Http/Request.php
+++ b/src/Framework/Http/Request.php
@@ -415,6 +415,19 @@ class Request extends ServerRequest implements Arrayable, ArrayAccess
 	}
 
 	/**
+	 * Retrieves the ETag values from the If-None-Match header.
+	 */
+	public function getETags(): array
+	{
+		return preg_split(
+			'/\s*,\s*/',
+			$this->headerBag->get('If-None-Match', ''),
+			-1,
+			PREG_SPLIT_NO_EMPTY
+		);
+	}
+
+	/**
 	 * Gets the format associated with the mime type.
 	 */
 	public function getFormat(string|null $mimeType = null): string|null

--- a/src/Framework/Http/Request.php
+++ b/src/Framework/Http/Request.php
@@ -7,7 +7,6 @@ use Closure;
 use Laminas\Diactoros\ServerRequest;
 use MVPS\Lumis\Framework\Contracts\Support\Arrayable;
 use MVPS\Lumis\Framework\Http\Traits\CanBePrecognitive;
-use MVPS\Lumis\Framework\Http\Traits\InteractsWithContent;
 use MVPS\Lumis\Framework\Http\Traits\InteractsWithContentTypes;
 use MVPS\Lumis\Framework\Http\Traits\InteractsWithRequestInput;
 use MVPS\Lumis\Framework\Routing\Route;
@@ -30,7 +29,6 @@ use Symfony\Component\HttpFoundation\ServerBag;
 class Request extends ServerRequest implements Arrayable, ArrayAccess
 {
 	use CanBePrecognitive;
-	use InteractsWithContent;
 	use InteractsWithContentTypes;
 	use InteractsWithRequestInput;
 
@@ -802,6 +800,17 @@ class Request extends ServerRequest implements Arrayable, ArrayAccess
 	}
 
 	/**
+	 * Determine if the current request URI matches a pattern.
+	 */
+	public function is(mixed ...$patterns): bool
+	{
+		$path = $this->decodedPath();
+
+		return collection($patterns)
+			->contains(fn ($pattern) => Str::is($pattern, $path));
+	}
+
+	/**
 	 * Indicates whether this request originated from a trusted proxy.
 	 *
 	 * This can be useful to determine whether or not to trust the
@@ -814,22 +823,19 @@ class Request extends ServerRequest implements Arrayable, ArrayAccess
 	}
 
 	/**
-	 * Determine if the current request URI matches a pattern.
-	 */
-	public function is(mixed ...$patterns): bool
-	{
-		$path = $this->decodedPath();
-
-		return collection($patterns)
-			->contains(fn ($pattern) => Str::is($pattern, $path));
-	}
-
-	/**
 	 * Checks if the request method matches the given type.
 	 */
 	public function isMethod(string $method): bool
 	{
 		return $this->getMethod() === strtoupper($method);
+	}
+
+	/**
+	 * Determines if the HTTP method is cacheable.
+	 */
+	public function isMethodCacheable(): bool
+	{
+		return in_array($this->getMethod(), ['GET', 'HEAD']);
 	}
 
 	/**

--- a/src/Framework/Http/Request.php
+++ b/src/Framework/Http/Request.php
@@ -872,6 +872,23 @@ class Request extends ServerRequest implements Arrayable, ArrayAccess
 	}
 
 	/**
+	 * Determines if the request method is considered "safe" according to RFC 7231.
+	 *
+	 * Safe methods are those that retrieve information or perform checks on a
+	 * resource without modifying its state. This method checks if the current
+	 * request method is one of the following: GET, HEAD, OPTIONS, or TRACE.
+	 *
+	 * @see https://tools.ietf.org/html/rfc7231#section-4.2.1
+	 */
+	public function isMethodSafe(): bool
+	{
+		return in_array(
+			strtoupper($this->getMethod()),
+			['GET', 'HEAD', 'OPTIONS', 'TRACE']
+		);
+	}
+
+	/**
 	 * Determine if the current request is secure (https).
 	 */
 	public function isSecure(): bool

--- a/src/Framework/Http/Response.php
+++ b/src/Framework/Http/Response.php
@@ -2,13 +2,27 @@
 
 namespace MVPS\Lumis\Framework\Http;
 
+use ArrayObject;
+use DateTimeImmutable;
+use Illuminate\Support\Traits\Macroable;
+use InvalidArgumentException;
+use JsonSerializable;
+use MVPS\Lumis\Framework\Contracts\Support\Arrayable;
+use MVPS\Lumis\Framework\Contracts\Support\Jsonable;
+use MVPS\Lumis\Framework\Contracts\Support\Renderable;
 use MVPS\Lumis\Framework\Http\Traits\ResponseTrait;
+use pdeans\Http\Factories\StreamFactory;
 use pdeans\Http\Response as BaseResponse;
+use RuntimeException;
+use stdClass;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 class Response extends BaseResponse
 {
 	use ResponseTrait;
+	use Macroable {
+		Macroable::__call as macroCall;
+	}
 
 	/**
 	 * The HTTP response charset.
@@ -18,6 +32,13 @@ class Response extends BaseResponse
 	protected string $charset = 'UTF-8';
 
 	/**
+	 * The HTTP response content.
+	 *
+	 * @var string
+	 */
+	protected string $content;
+
+	/**
 	 * The header bag instance for the headers.
 	 *
 	 * @var \Symfony\Component\HttpFoundation\ResponseHeaderBag
@@ -25,13 +46,26 @@ class Response extends BaseResponse
 	public ResponseHeaderBag $headerBag;
 
 	/**
+	 * Stores a list of headers already sent in informational responses.
+	 *
+	 * @var array
+	 */
+	private array $sentHeaders = [];
+
+	/**
 	 * Create a new HTTP response instance.
 	 */
-	public function __construct($body = 'php://memory', int $status = 200, array $headers = [])
+	public function __construct(mixed $content = '', $status = 200, array $headers = [])
 	{
-		parent::__construct(body: $body, status: $status, headers: $headers);
+		$this->headerBag = new ResponseHeaderBag($headers);
 
-		$this->headerBag = new ResponseHeaderBag($this->getHeaders());
+		$this->setContent($content);
+
+		parent::__construct(
+			body: (new StreamFactory)->createStream($this->content),
+			status: $status,
+			headers: $this->headerBag->all()
+		);
 	}
 
 	/**
@@ -59,11 +93,165 @@ class Response extends BaseResponse
 	}
 
 	/**
+	 * Determines if the response is cacheable by a shared (surrogate) cache.
+	 *
+	 * This method follows the guidelines outlined in RFC 7231 and RFC 7234 for
+	 * cacheability.
+	 *
+	 * A response is considered cacheable if it meets the following criteria:
+	 *
+	 * 1. Status code: The response status code is one of the commonly cacheable
+	 *    codes (e.g., 200, 301, 404).
+	 * 2. Cache-Control directives: The response does not have `no-store`
+	 *    directive or a private cache directive.
+	 * 3. Freshness or validation information: The response includes either a
+	 *    freshness lifetime (Expires, max-age) or a cache validator
+	 *    (Last-Modified, ETag).
+	 *
+	 * Note that RFC 7231 allows for more permissive implementations, but this
+	 * method prioritizes strict adherence to the standard.
+	 */
+	public function isCacheable(): bool
+	{
+		if (! in_array($this->getStatusCode(), [200, 203, 300, 301, 302, 404, 410])) {
+			return false;
+		}
+
+		if (
+			$this->headerBag->hasCacheControlDirective('no-store') ||
+			$this->headerBag->getCacheControlDirective('private')
+		) {
+			return false;
+		}
+
+		return $this->isValidateable() || $this->isFresh();
+	}
+
+	/**
+	 * Determines if the response is considered fresh.
+	 *
+	 * A fresh response can be served from cache without contacting the origin
+	 * server. This is based on the presence of Cache-Control/max-age or
+	 * Expires headers and their calculated age.
+	 */
+	public function isFresh(): bool
+	{
+		return $this->getTtl() > 0;
+	}
+
+	/**
+	 * Determines if the response is validatable.
+	 */
+	public function isValidateable(): bool
+	{
+		return $this->headerBag->has('Last-Modified') || $this->headerBag->has('ETag');
+	}
+
+	/**
+	 * Calculates the age of the response in seconds.
+	 */
+	public function getAge(): int
+	{
+		$age = $this->headerBag->get('Age');
+
+		if (! is_null($age)) {
+			return (int) $age;
+		}
+
+		return max(time() - (int) $this->getDate()->format('U'), 0);
+	}
+
+	/**
 	 * Get the HTTP response charset.
 	 */
 	public function getCharset(): string
 	{
 		return $this->charset;
+	}
+
+	/**
+	 * Gets the current response content.
+	 */
+	public function getContent(): string
+	{
+		return $this->content;
+	}
+
+	/**
+	 * Retrieves the Date header as a DateTimeImmutable instance.
+	 *
+	 * @throws \RuntimeException
+	 */
+	public function getDate(): DateTimeImmutable|null
+	{
+		return $this->headerBag->getDate('Date');
+	}
+
+	/**
+	 * Retrieves the Expires header as a DateTimeImmutable instance.
+	 */
+	public function getExpires(): DateTimeImmutable|null
+	{
+		try {
+			return $this->headerBag->getDate('Expires');
+		} catch (RuntimeException) {
+			// Invalid date formats (e.g., "0", "-1") must be treated as past
+			// dates according to RFC 2616.
+			return DateTimeImmutable::createFromFormat('U', time() - 172800);
+		}
+	}
+
+	/**
+	 * Calculates the maximum age of the response in seconds.
+	 */
+	public function getMaxAge(): int|null
+	{
+		if ($this->headerBag->hasCacheControlDirective('s-maxage')) {
+			return (int) $this->headerBag->getCacheControlDirective('s-maxage');
+		}
+
+		if ($this->headerBag->hasCacheControlDirective('max-age')) {
+			return (int) $this->headerBag->getCacheControlDirective('max-age');
+		}
+
+		$expires = $this->getExpires();
+
+		if (! is_null($expires)) {
+			$maxAge = (int) $expires->format('U') - (int) $this->getDate()->format('U');
+
+			return max($maxAge, 0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Calculates the time-to-live (TTL) for the response in seconds.
+	 *
+	 * Determines the remaining validity time based on the `max-age` directive
+	 * and response age. Returns null if no freshness information is available.
+	 * A TTL of 0 indicates that the response may require revalidation before
+	 * serving from cache.
+	 */
+	public function getTtl(): int|null
+	{
+		$maxAge = $this->getMaxAge();
+
+		return null !== $maxAge ? max($maxAge - $this->getAge(), 0) : null;
+	}
+
+	/**
+	 * Transform the given content to JSON.
+	 */
+	protected function morphToJson(mixed $content): string|bool
+	{
+		if ($content instanceof Jsonable) {
+			return $content->toJson();
+		} elseif ($content instanceof Arrayable) {
+			return json_encode($content->toArray());
+		}
+
+		return json_encode($content);
 	}
 
 	/**
@@ -88,16 +276,23 @@ class Response extends BaseResponse
 
 	/**
 	 * Sends HTTP headers and content.
+	 *
+	 * Optional parameter to determine if the output buffers should be flushed.
 	 */
-	public function send(): static
+	public function send(bool $flush = true): static
 	{
 		$this->sendHeaders();
 		$this->sendContent();
 
+		if (! $flush) {
+			return $this;
+		}
+
 		if (function_exists('fastcgi_finish_request')) {
 			fastcgi_finish_request();
-		} elseif (! in_array(PHP_SAPI, ['cli', 'phpdbg'], true)) {
+		} elseif (! in_array(PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)) {
 			static::closeOutputBuffers(0, true);
+
 			flush();
 		}
 
@@ -109,28 +304,77 @@ class Response extends BaseResponse
 	 */
 	public function sendContent(): static
 	{
-		echo (string) $this->getBody();
+		echo $this->content;
 
 		return $this;
 	}
 
 	/**
-	 * Sends HTTP headers for the current web response.
+	 * Sends HTTP headers to the client.
+	 *
+	 * Optional status code to override the default.
 	 */
-	public function sendHeaders(): static
+	public function sendHeaders(int|null $statusCode = null): static
 	{
-		foreach ($this->getHeaders() as $name => $values) {
+		// Headers already sent, no need to send again.
+		if (headers_sent()) {
+			return $this;
+		}
+
+		$informationalResponse = $statusCode >= static::MIN_STATUS_CODE_VALUE && $statusCode < 200;
+
+		// Skip informational responses if not supported by the SAPI.
+		if ($informationalResponse && ! function_exists('headers_send')) {
+			return $this;
+		}
+
+		foreach ($this->headerBag->allPreserveCaseWithoutCookies() as $name => $values) {
+			// PHP automatically copies headers from previous 103 responses
+			// (RFC 8297), so we need to handle potential header changes.
+			$previousValues = $this->sentHeaders[$name] ?? null;
+
+			// Header already sent in a previous 103 response, will be copied
+			// automatically by PHP.
+			if ($previousValues === $values) {
+				continue;
+			}
+
 			$replace = strcasecmp($name, 'Content-Type') === 0;
 
-			foreach ($values as $value) {
+			if (! is_null($previousValues) && array_diff($previousValues, $values)) {
+				header_remove($name);
+
+				$previousValues = null;
+			}
+
+			$newValues = is_null($previousValues) ? $values : array_diff($values, $previousValues);
+
+			foreach ($newValues as $value) {
 				header($name . ': ' . $value, $replace, $this->getStatusCode());
+			}
+
+			if ($informationalResponse) {
+				$this->sentHeaders[$name] = $values;
 			}
 		}
 
+		// Handle cookie headers
+		foreach ($this->headerBag->getCookies() as $cookie) {
+			header('Set-Cookie: ' . $cookie, false, $this->getStatusCode());
+		}
+
+		if ($informationalResponse) {
+			headers_send($statusCode);
+
+			return $this;
+		}
+
+		$statusCode ??= $this->getStatusCode();
+
 		header(
-			sprintf('HTTP/%s %s %s', $this->getProtocolVersion(), $this->getStatusCode(), $this->getReasonPhrase()),
+			sprintf('HTTP/%s %s %s', $this->getProtocolVersion(), $statusCode, $this->getReasonPhrase()),
 			true,
-			$this->getStatusCode()
+			$statusCode
 		);
 
 		return $this;
@@ -147,21 +391,48 @@ class Response extends BaseResponse
 	}
 
 	/**
-	 * Add an array of headers to the response.
+	 * Set the content on the response.
+	 *
+	 * @throws \InvalidArgumentException
 	 */
-	public function withHeaders(array $headers): Response
+	public function setContent(mixed $content): static
 	{
-		$response = clone $this;
+		$this->original = $content;
 
-		foreach ($headers as $name => $value) {
-			$response = $response->withHeader($name, $value);
+		if ($this->shouldBeJson($content)) {
+			$this->header('Content-Type', 'application/json');
+
+			$content = $this->morphToJson($content);
+
+			if ($content === false) {
+				throw new InvalidArgumentException(json_last_error_msg());
+			}
+		} elseif ($content instanceof Renderable) {
+			$content = $content->render();
+		} else {
+			$content = (string) $content;
 		}
 
-		return $response;
+		$this->content = $content;
+
+		return $this;
 	}
 
 	/**
-	 * Returns the response as an HTTP string.
+	 * Determine if the given content should be transformed into JSON.
+	 */
+	public function shouldBeJson(mixed $content): bool
+	{
+		return $content instanceof Arrayable ||
+			$content instanceof Jsonable ||
+			$content instanceof ArrayObject ||
+			$content instanceof JsonSerializable ||
+			$content instanceof stdClass ||
+			is_array($content);
+	}
+
+	/**
+	 * Returns the response as a string representation.
 	 *
 	 * The string representation of the response is the same as the one
 	 * that will be sent to the client only if the prepare() method has
@@ -180,11 +451,9 @@ class Response extends BaseResponse
 			$this->getReasonPhrase()
 		) . $eol;
 
-		foreach ($this->getHeaders() as $name => $value) {
-			$output .= $name . ': ' . $this->getHeaderLine($name) . $eol;
-		}
+		$output .= $this->headerBag . $eol;
 
-		$output .= $eol . (string) $this->getBody();
+		$output .= $this->getContent();
 
 		return $output;
 	}

--- a/src/Framework/Http/Response.php
+++ b/src/Framework/Http/Response.php
@@ -255,19 +255,19 @@ class Response extends BaseResponse
 	}
 
 	/**
-	 * Determines if the response status code indicates an empty response.
-	 */
-	public function isEmpty(): bool
-	{
-		return in_array($this->getStatusCode(), [204, 304]);
-	}
-
-	/**
 	 * Determines if the response status code indicates a client error.
 	 */
 	public function isClientError(): bool
 	{
 		return $this->getStatusCode() >= 400 && $this->getStatusCode() < 500;
+	}
+
+	/**
+	 * Determines if the response status code indicates an empty response.
+	 */
+	public function isEmpty(): bool
+	{
+		return in_array($this->getStatusCode(), [204, 304]);
 	}
 
 	/**

--- a/src/Framework/Http/Response.php
+++ b/src/Framework/Http/Response.php
@@ -916,6 +916,15 @@ class Response extends BaseResponse
 	}
 
 	/**
+	 * {@inheritdoc}
+	 */
+	#[\Override]
+	public function withStatus(int $code, string $reasonPhrase = ''): static
+	{
+		return parent::withStatus($code, $reasonPhrase);
+	}
+
+	/**
 	 * Returns the response as a string representation.
 	 *
 	 * The string representation of the response is the same as the one

--- a/src/Framework/Http/Response.php
+++ b/src/Framework/Http/Response.php
@@ -143,7 +143,7 @@ class Response extends BaseResponse
 	/**
 	 * Gets the current response content.
 	 */
-	public function getContent(): string
+	public function getContent(): string|false
 	{
 		return $this->content;
 	}
@@ -178,6 +178,16 @@ class Response extends BaseResponse
 			// dates according to RFC 2616.
 			return DateTimeImmutable::createFromFormat('U', time() - 172800);
 		}
+	}
+
+	/**
+	 * Retrieves the Last-Modified header as a DateTimeImmutable instance.
+	 *
+	 * @throws \RuntimeException
+	 */
+	public function getLastModified(): DateTimeImmutable|null
+	{
+		return $this->headerBag->getDate('Last-Modified');
 	}
 
 	/**

--- a/src/Framework/Http/Response.php
+++ b/src/Framework/Http/Response.php
@@ -62,7 +62,7 @@ class Response extends BaseResponse
 	 *
 	 * @var string
 	 */
-	protected string $content;
+	protected string $content = '';
 
 	/**
 	 * The header bag instance for the headers.

--- a/src/Framework/Http/Response.php
+++ b/src/Framework/Http/Response.php
@@ -725,6 +725,33 @@ class Response extends BaseResponse
 	}
 
 	/**
+	 * Prepares the response for a 304 Not Modified status code.
+	 *
+	 * @see https://tools.ietf.org/html/rfc2616#section-10.3.5
+	 */
+	public function setNotModified(): static
+	{
+		$this->setContent(null);
+
+		// Remove headers prohibited by RFC 2616 for 304 Not Modified responses.
+		foreach (
+			[
+				'Allow',
+				'Content-Encoding',
+				'Content-Language',
+				'Content-Length',
+				'Content-MD5',
+				'Content-Type',
+				'Last-Modified'
+			] as $header
+		) {
+			$this->headerBag->remove($header);
+		}
+
+		return $this;
+	}
+
+	/**
 	 * Sets the "private" cache control directive.
 	 *
 	 * Prevents the response from being cached by intermediate proxies.
@@ -803,33 +830,6 @@ class Response extends BaseResponse
 			$content instanceof JsonSerializable ||
 			$content instanceof stdClass ||
 			is_array($content);
-	}
-
-	/**
-	 * Prepares the response for a 304 Not Modified status code.
-	 *
-	 * @see https://tools.ietf.org/html/rfc2616#section-10.3.5
-	 */
-	public function setNotModified(): static
-	{
-		$this->setContent(null);
-
-		// Remove headers prohibited by RFC 2616 for 304 Not Modified responses.
-		foreach (
-			[
-				'Allow',
-				'Content-Encoding',
-				'Content-Language',
-				'Content-Length',
-				'Content-MD5',
-				'Content-Type',
-				'Last-Modified'
-			] as $header
-		) {
-			$this->headerBag->remove($header);
-		}
-
-		return $this;
 	}
 
 	/**

--- a/src/Framework/Http/Response.php
+++ b/src/Framework/Http/Response.php
@@ -13,6 +13,7 @@ use MVPS\Lumis\Framework\Contracts\Support\Arrayable;
 use MVPS\Lumis\Framework\Contracts\Support\Jsonable;
 use MVPS\Lumis\Framework\Contracts\Support\Renderable;
 use MVPS\Lumis\Framework\Http\Traits\ResponseTrait;
+use MVPS\Lumis\Framework\Http\Traits\StatusCodes;
 use pdeans\Http\Factories\StreamFactory;
 use pdeans\Http\Response as BaseResponse;
 use RuntimeException;
@@ -21,6 +22,7 @@ use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 class Response extends BaseResponse
 {
+	use StatusCodes;
 	use ResponseTrait;
 	use Macroable {
 		Macroable::__call as macroCall;

--- a/src/Framework/Http/StreamedResponse.php
+++ b/src/Framework/Http/StreamedResponse.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Http;
+
+use Closure;
+use LogicException;
+
+class StreamedResponse extends Response
+{
+	/**
+	 * The callback function to be executed for each chunk of data.
+	 *
+	 * @var \Closure|null
+	 */
+	protected Closure|null $callback = null;
+
+	/**
+	 * Tracks whether the response headers have been sent.
+	 *
+	 * @var bool
+	 */
+	private bool $headersSent = false;
+
+	/**
+	 * Indicates whether the response has been streamed.
+	 *
+	 * @var bool
+	 */
+	protected bool $streamed = false;
+
+	/**
+	 * Create a new streamed HTTP response instance.
+	 */
+	public function __construct(callable|null $callback = null, int $status = 200, array $headers = [])
+	{
+		parent::__construct(null, $status, $headers);
+
+		if (! is_null($callback)) {
+			$this->setCallback($callback);
+		}
+	}
+
+	/**
+	 * Retrieves the callback function for the response.
+	 */
+	public function getCallback(): Closure|null
+	{
+		if (! isset($this->callback)) {
+			return null;
+		}
+
+		return ($this->callback)(...);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getContent(): string|false
+	{
+		return false;
+	}
+
+	/**
+	 * Sends the response content.
+	 *
+	 * Executes the callback function to stream the content,
+	 * ensuring it's sent only once.
+	 */
+	public function sendContent(): static
+	{
+		if ($this->streamed) {
+			return $this;
+		}
+
+		$this->streamed = true;
+
+		if (! isset($this->callback)) {
+			throw new LogicException('The response callback must be set.');
+		}
+
+		($this->callback)();
+
+		return $this;
+	}
+
+	/**
+	 * Sends HTTP headers if not already sent.
+	 */
+	public function sendHeaders(int|null $statusCode = null): static
+	{
+		if ($this->headersSent) {
+			return $this;
+		}
+
+		if ($statusCode < static::MIN_STATUS_CODE_VALUE || $statusCode >= 200) {
+			$this->headersSent = true;
+		}
+
+		return parent::sendHeaders($statusCode);
+	}
+
+	/**
+	 * Sets the callback function for streaming the response content.
+	 */
+	public function setCallback(callable $callback): static
+	{
+		$this->callback = $callback(...);
+
+		return $this;
+	}
+
+	/**
+	 * Prevents setting content on a streamed response.
+	 *
+	 * @throws \LogicException
+	 */
+	public function setContent(mixed $content): static
+	{
+		if (! is_null($content)) {
+			throw new LogicException(
+				'Setting content on a StreamedResponse is not supported.' .
+				' Use the callback property to provide content.'
+			);
+		}
+
+		$this->streamed = true;
+
+		return $this;
+	}
+}

--- a/src/Framework/Http/Traits/InteractsWithContentTypes.php
+++ b/src/Framework/Http/Traits/InteractsWithContentTypes.php
@@ -59,21 +59,6 @@ trait InteractsWithContentTypes
 	}
 
 	/**
-	 * Determine if the given content types match.
-	 */
-	public static function matchesType(string $actual, string $type): bool
-	{
-		if ($actual === $type) {
-			return true;
-		}
-
-		$split = explode('/', $actual);
-
-		return isset($split[1]) &&
-			preg_match('#' . preg_quote($split[0], '#') . '/.+\+' . preg_quote($split[1], '#') . '#', $type);
-	}
-
-	/**
 	 * Determines whether a request accepts JSON.
 	 */
 	public function acceptsJson(): bool
@@ -111,6 +96,21 @@ trait InteractsWithContentTypes
 	public function isJson(): bool
 	{
 		return Str::contains($this->header('Content-Type', ''), ['/json', '+json']);
+	}
+
+	/**
+	 * Determine if the given content types match.
+	 */
+	public static function matchesType(string $actual, string $type): bool
+	{
+		if ($actual === $type) {
+			return true;
+		}
+
+		$split = explode('/', $actual);
+
+		return isset($split[1]) &&
+			preg_match('#' . preg_quote($split[0], '#') . '/.+\+' . preg_quote($split[1], '#') . '#', $type);
 	}
 
 	/**

--- a/src/Framework/Http/Traits/InteractsWithHeaders.php
+++ b/src/Framework/Http/Traits/InteractsWithHeaders.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Http\Traits;
+
+trait InteractsWithHeaders
+{
+	/**
+	 * Inject the provided Content-Type, if none is already present.
+	 *
+	 * @return array Headers with injected Content-Type
+	 */
+	public function injectContentType(string $contentType, array $headers): array
+	{
+		$hasContentType = array_reduce(
+			array_keys($headers),
+			static fn($carry, $item) => $carry ?: strtolower($item) === 'content-type',
+			false
+		);
+
+		if (! $hasContentType) {
+			$headers['content-type'] = [$contentType];
+		}
+
+		return $headers;
+	}
+}

--- a/src/Framework/Http/Traits/InteractsWithHeaders.php
+++ b/src/Framework/Http/Traits/InteractsWithHeaders.php
@@ -6,8 +6,6 @@ trait InteractsWithHeaders
 {
 	/**
 	 * Inject the provided Content-Type, if none is already present.
-	 *
-	 * @return array Headers with injected Content-Type
 	 */
 	public function injectContentType(string $contentType, array $headers): array
 	{

--- a/src/Framework/Http/Traits/ResponseTrait.php
+++ b/src/Framework/Http/Traits/ResponseTrait.php
@@ -27,7 +27,7 @@ trait ResponseTrait
 	 */
 	public function content(): string
 	{
-		return (string) $this->getBody();
+		return $this->getContent();
 	}
 
 	/**

--- a/src/Framework/Http/Traits/ResponseTrait.php
+++ b/src/Framework/Http/Traits/ResponseTrait.php
@@ -40,8 +40,10 @@ trait ResponseTrait
 
 	/**
 	 * Get the callback of the response.
+	 *
+	 * @return string|null
 	 */
-	public function getCallback(): string|null
+	public function getCallback()
 	{
 		return $this->callback ?? null;
 	}

--- a/src/Framework/Http/Traits/StatusCodes.php
+++ b/src/Framework/Http/Traits/StatusCodes.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Http\Traits;
+
+trait StatusCodes
+{
+	public const HTTP_CONTINUE = 100;
+	public const HTTP_SWITCHING_PROTOCOLS = 101;
+	public const HTTP_PROCESSING = 102;
+	public const HTTP_EARLY_HINTS = 103;
+	public const HTTP_OK = 200;
+	public const HTTP_CREATED = 201;
+	public const HTTP_ACCEPTED = 202;
+	public const HTTP_NON_AUTHORITATIVE_INFORMATION = 203;
+	public const HTTP_NO_CONTENT = 204;
+	public const HTTP_RESET_CONTENT = 205;
+	public const HTTP_PARTIAL_CONTENT = 206;
+	public const HTTP_MULTI_STATUS = 207;
+	public const HTTP_ALREADY_REPORTED = 208;
+	public const HTTP_IM_USED = 226;
+	public const HTTP_MULTIPLE_CHOICES = 300;
+	public const HTTP_MOVED_PERMANENTLY = 301;
+	public const HTTP_FOUND = 302;
+	public const HTTP_SEE_OTHER = 303;
+	public const HTTP_NOT_MODIFIED = 304;
+	public const HTTP_USE_PROXY = 305;
+	public const HTTP_RESERVED = 306;
+	public const HTTP_TEMPORARY_REDIRECT = 307;
+	public const HTTP_PERMANENTLY_REDIRECT = 308;
+	public const HTTP_BAD_REQUEST = 400;
+	public const HTTP_UNAUTHORIZED = 401;
+	public const HTTP_PAYMENT_REQUIRED = 402;
+	public const HTTP_FORBIDDEN = 403;
+	public const HTTP_NOT_FOUND = 404;
+	public const HTTP_METHOD_NOT_ALLOWED = 405;
+	public const HTTP_NOT_ACCEPTABLE = 406;
+	public const HTTP_PROXY_AUTHENTICATION_REQUIRED = 407;
+	public const HTTP_REQUEST_TIMEOUT = 408;
+	public const HTTP_CONFLICT = 409;
+	public const HTTP_GONE = 410;
+	public const HTTP_LENGTH_REQUIRED = 411;
+	public const HTTP_PRECONDITION_FAILED = 412;
+	public const HTTP_REQUEST_ENTITY_TOO_LARGE = 413;
+	public const HTTP_REQUEST_URI_TOO_LONG = 414;
+	public const HTTP_UNSUPPORTED_MEDIA_TYPE = 415;
+	public const HTTP_REQUESTED_RANGE_NOT_SATISFIABLE = 416;
+	public const HTTP_EXPECTATION_FAILED = 417;
+	public const HTTP_I_AM_A_TEAPOT = 418;
+	public const HTTP_MISDIRECTED_REQUEST = 421;
+	public const HTTP_UNPROCESSABLE_ENTITY = 422;
+	public const HTTP_LOCKED = 423;
+	public const HTTP_FAILED_DEPENDENCY = 424;
+	public const HTTP_TOO_EARLY = 425;
+	public const HTTP_UPGRADE_REQUIRED = 426;
+	public const HTTP_PRECONDITION_REQUIRED = 428;
+	public const HTTP_TOO_MANY_REQUESTS = 429;
+	public const HTTP_REQUEST_HEADER_FIELDS_TOO_LARGE = 431;
+	public const HTTP_UNAVAILABLE_FOR_LEGAL_REASONS = 451;
+	public const HTTP_INTERNAL_SERVER_ERROR = 500;
+	public const HTTP_NOT_IMPLEMENTED = 501;
+	public const HTTP_BAD_GATEWAY = 502;
+	public const HTTP_SERVICE_UNAVAILABLE = 503;
+	public const HTTP_GATEWAY_TIMEOUT = 504;
+	public const HTTP_VERSION_NOT_SUPPORTED = 505;
+	public const HTTP_VARIANT_ALSO_NEGOTIATES_EXPERIMENTAL = 506;
+	public const HTTP_INSUFFICIENT_STORAGE = 507;
+	public const HTTP_LOOP_DETECTED = 508;
+	public const HTTP_NOT_EXTENDED = 510;
+	public const HTTP_NETWORK_AUTHENTICATION_REQUIRED = 511;
+}

--- a/src/Framework/Providers/DefaultProviders.php
+++ b/src/Framework/Providers/DefaultProviders.php
@@ -3,6 +3,7 @@
 namespace MVPS\Lumis\Framework\Providers;
 
 use MVPS\Lumis\Framework\Console\ConsoleSupportServiceProvider;
+use MVPS\Lumis\Framework\Cookie\CookieServiceProvider;
 use MVPS\Lumis\Framework\Database\DatabaseServiceProvider;
 use MVPS\Lumis\Framework\Filesystem\FilesystemServiceProvider;
 use MVPS\Lumis\Framework\Pipeline\PipelineServiceProvider;
@@ -25,6 +26,7 @@ class DefaultProviders
 		$this->providers = $providers ?: [
 			// CacheServiceProvider::class,
 			ConsoleSupportServiceProvider::class,
+			CookieServiceProvider::class,
 			DatabaseServiceProvider::class,
 			// EncryptionServiceProvider::class,
 			FilesystemServiceProvider::class,

--- a/src/Framework/Routing/Exceptions/StreamedResponseException.php
+++ b/src/Framework/Routing/Exceptions/StreamedResponseException.php
@@ -27,10 +27,8 @@ class StreamedResponseException extends RuntimeException
 
 	/**
 	 * Get the actual exception thrown during the stream.
-	 *
-	 * @return \Throwable
 	 */
-	public function getInnerException()
+	public function getInnerException(): Throwable
 	{
 		return $this->originalException;
 	}

--- a/src/Framework/Routing/Exceptions/StreamedResponseException.php
+++ b/src/Framework/Routing/Exceptions/StreamedResponseException.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Routing\Exceptions;
+
+use MVPS\Lumis\Framework\Http\Response;
+use RuntimeException;
+use Throwable;
+
+class StreamedResponseException extends RuntimeException
+{
+	/**
+	 * The actual exception thrown during the stream.
+	 *
+	 * @var Throwable
+	 */
+	public $originalException;
+
+	/**
+	 * Create a new streamed response exception instance.
+	 */
+	public function __construct(Throwable $originalException)
+	{
+		$this->originalException = $originalException;
+
+		parent::__construct($originalException->getMessage());
+	}
+
+	/**
+	 * Get the actual exception thrown during the stream.
+	 *
+	 * @return \Throwable
+	 */
+	public function getInnerException()
+	{
+		return $this->originalException;
+	}
+
+	/**
+	 * Render the exception.
+	 */
+	public function render(): Response
+	{
+		return new Response('');
+	}
+}

--- a/src/Framework/Routing/Exceptions/StreamedResponseException.php
+++ b/src/Framework/Routing/Exceptions/StreamedResponseException.php
@@ -13,7 +13,7 @@ class StreamedResponseException extends RuntimeException
 	 *
 	 * @var Throwable
 	 */
-	public $originalException;
+	public Throwable $originalException;
 
 	/**
 	 * Create a new streamed response exception instance.

--- a/src/Framework/Routing/RedirectController.php
+++ b/src/Framework/Routing/RedirectController.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Routing;
+
+use MVPS\Lumis\Framework\Http\RedirectResponse;
+use MVPS\Lumis\Framework\Http\Request;
+use MVPS\Lumis\Framework\Support\Str;
+
+class RedirectController extends Controller
+{
+	/**
+	 * Invoke the redirect controller method.
+	 */
+	public function __invoke(Request $request, UrlGenerator $url): RedirectResponse
+	{
+		$parameters = collection($request->route()->parameters());
+
+		$status = $parameters->get('status');
+		$destination = $parameters->get('destination');
+
+		$parameters->forget('status')
+			->forget('destination');
+
+		$route = (new Route('GET', $destination, ['as' => 'lumis_route_redirect_destination']))
+			->bind($request);
+
+		$parameters = $parameters->only($route->getCompiled()->getPathVariables())
+			->all();
+
+		$url = $url->toRoute($route, $parameters, false);
+
+		if (! str_starts_with($destination, '/') && str_starts_with($url, '/')) {
+			$url = Str::after($url, '/');
+		}
+
+		return new RedirectResponse($url, $status);
+	}
+}

--- a/src/Framework/Routing/Redirector.php
+++ b/src/Framework/Routing/Redirector.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Routing;
+
+use DateInterval;
+use DateTimeInterface;
+use Illuminate\Support\Traits\Macroable;
+use MVPS\Lumis\Framework\Http\RedirectResponse;
+use MVPS\Lumis\Framework\Session\Store as SessionStore;
+
+class Redirector
+{
+	use Macroable;
+
+	/**
+	 * The URL generator instance.
+	 *
+	 * @var \MVPS\Lumis\Framework\Routing\UrlGenerator
+	 */
+	protected UrlGenerator $generator;
+
+	/**
+	 * The session store instance.
+	 *
+	 * @var \MVPS\Lumis\Framework\Session\Store|null
+	 */
+	protected SessionStore|null $session = null;
+
+	/**
+	 * Create a new redirector instance.
+	 */
+	public function __construct(UrlGenerator $generator)
+	{
+		$this->generator = $generator;
+	}
+
+	/**
+	 * Create a new redirect response to a controller action.
+	 */
+	public function action(
+		string|array $action,
+		mixed $parameters = [],
+		int $status = 302,
+		array $headers = []
+	): RedirectResponse {
+		return $this->to($this->generator->action($action, $parameters), $status, $headers);
+	}
+
+	/**
+	 * Creates a redirect response to an external URL.
+	 *
+	 * Bypasses URL validation for external redirects.
+	 */
+	public function away(string $path, int $status = 302, array $headers = []): RedirectResponse
+	{
+		return $this->createRedirect($path, $status, $headers);
+	}
+
+	/**
+	 * Create a new redirect response to the previous location.
+	 */
+	public function back(int $status = 302, array $headers = [], mixed $fallback = false): RedirectResponse
+	{
+		return $this->createRedirect($this->generator->previous($fallback), $status, $headers);
+	}
+
+	/**
+	 * Create a new redirect response.
+	 */
+	protected function createRedirect(string $path, int $status, array $headers): RedirectResponse
+	{
+		return tap(new RedirectResponse($path, $status, $headers), function ($redirect) {
+			if (isset($this->session)) {
+				$redirect->setSession($this->session);
+			}
+
+			$redirect->setRequest($this->generator->getRequest());
+		});
+	}
+
+
+	/**
+	 * Create a new redirect response to the previously intended location.
+	 */
+	public function intended(
+		mixed $default = '/',
+		int $status = 302,
+		array $headers = [],
+		bool|null $secure = null
+	): RedirectResponse {
+		$path = $this->session->pull('url.intended', $default);
+
+		return $this->to($path, $status, $headers, $secure);
+	}
+
+	/**
+	 * Get the "intended" URL from the session.
+	 */
+	public function getIntendedUrl(): string|null
+	{
+		return $this->session->get('url.intended');
+	}
+
+	/**
+	 * Get the URL generator instance.
+	 */
+	public function getUrlGenerator(): UrlGenerator
+	{
+		return $this->generator;
+	}
+
+	/**
+	 * Create a new redirect response, while putting the
+	 * current URL in the session.
+	 */
+	public function guest(
+		string $path,
+		int $status = 302,
+		array $headers = [],
+		bool|null $secure = null
+	): RedirectResponse {
+		$request = $this->generator->getRequest();
+
+		$intended = $request->isMethod('GET') && $request->route() && ! $request->expectsJson()
+			? $this->generator->full()
+			: $this->generator->previous();
+
+		if ($intended) {
+			$this->setIntendedUrl($intended);
+		}
+
+		return $this->to($path, $status, $headers, $secure);
+	}
+
+	/**
+	 * Create a new redirect response to the current URI.
+	 */
+	public function refresh(int $status = 302, array $headers = []): RedirectResponse
+	{
+		return $this->to($this->generator->getRequest()->getPath(), $status, $headers);
+	}
+
+	/**
+	 * Create a new redirect response to a named route.
+	 */
+	public function route(
+		string $route,
+		mixed $parameters = [],
+		int $status = 302,
+		array $headers = []
+	): RedirectResponse {
+		return $this->to($this->generator->route($route, $parameters), $status, $headers);
+	}
+
+	/**
+	 * Create a new redirect response to the given HTTPS path.
+	 */
+	public function secure(string $path, int $status = 302, array $headers = []): RedirectResponse
+	{
+		return $this->to($path, $status, $headers, true);
+	}
+
+	/**
+	 * Set the "intended" URL in the session.
+	 */
+	public function setIntendedUrl(string $url): static
+	{
+		$this->session->put('url.intended', $url);
+
+		return $this;
+	}
+
+	/**
+	 * Set the active session store.
+	 */
+	public function setSession(SessionStore $session): void
+	{
+		$this->session = $session;
+	}
+
+	/**
+	 * Create a new redirect response to a signed named route.
+	 */
+	public function signedRoute(
+		string $route,
+		mixed $parameters = [],
+		DateTimeInterface|DateInterval|int|null $expiration = null,
+		int $status = 302,
+		array $headers = []
+	): RedirectResponse {
+		return $this->to($this->generator->signedRoute($route, $parameters, $expiration), $status, $headers);
+	}
+
+	/**
+	 * Create a new redirect response to a signed named route.
+	 */
+	public function temporarySignedRoute(
+		string $route,
+		DateTimeInterface|DateInterval|int|null $expiration,
+		mixed $parameters = [],
+		int $status = 302,
+		array $headers = []
+	): RedirectResponse {
+		return $this->to($this->generator->temporarySignedRoute($route, $expiration, $parameters), $status, $headers);
+	}
+
+	/**
+	 * Create a new redirect response to the given path.
+	 */
+	public function to(string $path, int $status = 302, array $headers = [], bool|null $secure = null): RedirectResponse
+	{
+		return $this->createRedirect($this->generator->to($path, [], $secure), $status, $headers);
+	}
+}

--- a/src/Framework/Routing/ResponseFactory.php
+++ b/src/Framework/Routing/ResponseFactory.php
@@ -5,8 +5,11 @@ namespace MVPS\Lumis\Framework\Routing;
 use Illuminate\Support\Traits\Macroable;
 use MVPS\Lumis\Framework\Contracts\Routing\ResponseFactory as ResponseFactoryContract;
 use MVPS\Lumis\Framework\Contracts\View\Factory as ViewFactory;
+use MVPS\Lumis\Framework\Http\BinaryFileResponse;
 use MVPS\Lumis\Framework\Http\JsonResponse;
 use MVPS\Lumis\Framework\Http\Response;
+use MVPS\Lumis\Framework\Support\Str;
+use SplFileInfo;
 
 class ResponseFactory implements ResponseFactoryContract
 {
@@ -25,6 +28,41 @@ class ResponseFactory implements ResponseFactoryContract
 	public function __construct(ViewFactory $view)
 	{
 		$this->view = $view;
+	}
+
+	/**
+	 * Create a new file download response.
+	 */
+	public function download(
+		SplFileInfo|string $file,
+		string|null $name = null,
+		array $headers = [],
+		string|null $disposition = 'attachment'
+	): BinaryFileResponse {
+		$response = new BinaryFileResponse($file, 200, $headers, true, $disposition);
+
+		if (! is_null($name)) {
+			return $response->setContentDisposition($disposition, $name, $this->fallbackName($name));
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Converts a string to ASCII characters that are
+	 * equivalent to the given name.
+	 */
+	protected function fallbackName(string $name): string
+	{
+		return str_replace('%', '', Str::ascii($name));
+	}
+
+	/**
+	 * Return the raw contents of a binary file.
+	 */
+	public function file(SplFileInfo|string $file, array $headers = []): BinaryFileResponse
+	{
+		return new BinaryFileResponse($file, 200, $headers);
 	}
 
 	public function json(mixed $data = [], int $status = 200, array $headers = [], int $options = 0): JsonResponse

--- a/src/Framework/Routing/ResponseFactory.php
+++ b/src/Framework/Routing/ResponseFactory.php
@@ -7,6 +7,7 @@ use MVPS\Lumis\Framework\Contracts\Routing\ResponseFactory as ResponseFactoryCon
 use MVPS\Lumis\Framework\Contracts\View\Factory as ViewFactory;
 use MVPS\Lumis\Framework\Http\BinaryFileResponse;
 use MVPS\Lumis\Framework\Http\JsonResponse;
+use MVPS\Lumis\Framework\Http\RedirectResponse;
 use MVPS\Lumis\Framework\Http\Response;
 use MVPS\Lumis\Framework\Http\StreamedResponse;
 use MVPS\Lumis\Framework\Routing\Exceptions\StreamedResponseException;
@@ -19,6 +20,13 @@ class ResponseFactory implements ResponseFactoryContract
 	use Macroable;
 
 	/**
+	 * The redirector instance.
+	 *
+	 * @var \MVPS\Lumis\Framework\Routing\Redirector
+	 */
+	protected Redirector $redirector;
+
+	/**
 	 * The view factory instance.
 	 *
 	 * @var \MVPS\Lumis\Framework\Contracts\View\Factory
@@ -28,9 +36,10 @@ class ResponseFactory implements ResponseFactoryContract
 	/**
 	 * Create a new response factory instance.
 	 */
-	public function __construct(ViewFactory $view)
+	public function __construct(ViewFactory $view, Redirector $redirector)
 	{
 		$this->view = $view;
+		$this->redirector = $redirector;
 	}
 
 	/**
@@ -100,6 +109,67 @@ class ResponseFactory implements ResponseFactoryContract
 	public function noContent(int $status = 204, array $headers = []): Response
 	{
 		return $this->make('', $status, $headers);
+	}
+
+	/**
+	 * Create a new redirect response, while putting the
+	 * current URLin the session.
+	 */
+	public function redirectGuest(
+		string $path,
+		int $status = 302,
+		array $headers = [],
+		bool|null $secure = null
+	): RedirectResponse {
+		return $this->redirector->guest($path, $status, $headers, $secure);
+	}
+
+	/**
+	 * Create a new redirect response to the given path.
+	 */
+	public function redirectTo(
+		string $path,
+		int $status = 302,
+		array $headers = [],
+		bool|null $secure = null
+	): RedirectResponse {
+		return $this->redirector->to($path, $status, $headers, $secure);
+	}
+
+	/**
+	 * Create a new redirect response to a controller action.
+	 */
+	public function redirectToAction(
+		array|string $action,
+		mixed $parameters = [],
+		int $status = 302,
+		array $headers = []
+	): RedirectResponse {
+		return $this->redirector->action($action, $parameters, $status, $headers);
+	}
+
+	/**
+	 * Create a new redirect response to the previously intended location.
+	 */
+	public function redirectToIntended(
+		string $default = '/',
+		int $status = 302,
+		array $headers = [],
+		bool|null $secure = null
+	): RedirectResponse {
+		return $this->redirector->intended($default, $status, $headers, $secure);
+	}
+
+	/**
+	 * Create a new redirect response to a named route.
+	 */
+	public function redirectToRoute(
+		string $route,
+		mixed $parameters = [],
+		int $status = 302,
+		array $headers = []
+	): RedirectResponse {
+		return $this->redirector->route($route, $parameters, $status, $headers);
 	}
 
 	/**

--- a/src/Framework/Routing/ResponseFactory.php
+++ b/src/Framework/Routing/ResponseFactory.php
@@ -5,6 +5,7 @@ namespace MVPS\Lumis\Framework\Routing;
 use Illuminate\Support\Traits\Macroable;
 use MVPS\Lumis\Framework\Contracts\Routing\ResponseFactory as ResponseFactoryContract;
 use MVPS\Lumis\Framework\Contracts\View\Factory as ViewFactory;
+use MVPS\Lumis\Framework\Http\JsonResponse;
 use MVPS\Lumis\Framework\Http\Response;
 
 class ResponseFactory implements ResponseFactoryContract
@@ -24,6 +25,24 @@ class ResponseFactory implements ResponseFactoryContract
 	public function __construct(ViewFactory $view)
 	{
 		$this->view = $view;
+	}
+
+	public function json(mixed $data = [], int $status = 200, array $headers = [], int $options = 0): JsonResponse
+	{
+		return new JsonResponse($data, $status, $headers, $options);
+	}
+
+	/**
+	 * Create a new JSONP response instance.
+	 */
+	public function jsonp(
+		string $callback,
+		mixed $data = [],
+		int $status = 200,
+		array $headers = [],
+		int $options = 0
+	): JsonResponse {
+		return $this->json($data, $status, $headers, $options)->setCallback($callback);
 	}
 
 	/**

--- a/src/Framework/Routing/Router.php
+++ b/src/Framework/Routing/Router.php
@@ -1086,7 +1086,7 @@ class Router implements BindingRegistrar, RegistrarContract
 		// 	$response->setNotModified();
 		// }
 
-		return $response->prepare();
+		return $response->prepare($request);
 	}
 
 	/**

--- a/src/Framework/Routing/RoutingServiceProvider.php
+++ b/src/Framework/Routing/RoutingServiceProvider.php
@@ -22,6 +22,7 @@ class RoutingServiceProvider extends ServiceProvider
 	{
 		$this->registerRouter();
 		$this->registerUrlGenerator();
+		$this->registerRedirector();
 		$this->registerResponseFactory();
 		$this->registerCallableDispatcher();
 		$this->registerControllerDispatcher();
@@ -48,12 +49,30 @@ class RoutingServiceProvider extends ServiceProvider
 	}
 
 	/**
+	 * Register the redirector service.
+	 */
+	protected function registerRedirector(): void
+	{
+		$this->app->singleton('redirect', function ($app) {
+			$redirector = new Redirector($app['url']);
+
+			// Inject the session instance into the redirector if available,
+			// enabling the use of flash data for redirects (ie "with" methods).
+			if (isset($app['session.store'])) {
+				$redirector->setSession($app['session.store']);
+			}
+
+			return $redirector;
+		});
+	}
+
+	/**
 	 * Register the response factory implementation.
 	 */
 	protected function registerResponseFactory(): void
 	{
 		$this->app->singleton(ResponseFactoryContract::class, function ($app) {
-			return new ResponseFactory($app[ViewFactoryContract::class]);
+			return new ResponseFactory($app[ViewFactoryContract::class], $app['redirect']);
 		});
 	}
 

--- a/src/Framework/Session/CookieSessionHandler.php
+++ b/src/Framework/Session/CookieSessionHandler.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace MVPS\Lumis\Framework\Session;
+
+use Illuminate\Support\InteractsWithTime;
+use MVPS\Lumis\Framework\Contracts\Cookie\QueueingFactory as CookieJar;
+use MVPS\Lumis\Framework\Http\Request;
+use SessionHandlerInterface;
+
+class CookieSessionHandler implements SessionHandlerInterface
+{
+	use InteractsWithTime;
+
+	/**
+	 * The cookie jar instance.
+	 *
+	 * @var \MVPS\Lumis\Framework\Contracts\Cookie\Factory
+	 */
+	protected CookieJar $cookie;
+
+	/**
+	 * Indicates whether the session should be expired when the browser closes.
+	 *
+	 * @var bool
+	 */
+	protected bool $expireOnClose;
+
+	/**
+	 * The number of minutes the session should be valid.
+	 *
+	 * @var int
+	 */
+	protected int $minutes;
+
+	/**
+	 * The request instance.
+	 *
+	 * @var \MVPS\Lumis\Framework\Http\Request
+	 */
+	protected Request|null $request = null;
+
+	/**
+	 * Create a new cookie session handler instance.
+	 */
+	public function __construct(CookieJar $cookie, int $minutes, bool $expireOnClose = false)
+	{
+		$this->cookie = $cookie;
+		$this->minutes = $minutes;
+		$this->expireOnClose = $expireOnClose;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function close(): bool
+	{
+		return true;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function destroy($sessionId): bool
+	{
+		$this->cookie->queue($this->cookie->forget($sessionId));
+
+		return true;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function gc($lifetime): int
+	{
+		return 0;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function open($savePath, $sessionName): bool
+	{
+		return true;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function read($sessionId): string|false
+	{
+		$value = $this->request->cookies->get($sessionId) ?: '';
+
+		$decoded = json_decode($value, true);
+
+		if (
+			! is_null($decoded) &&
+			is_array($decoded) &&
+			isset($decoded['expires']) &&
+			$this->currentTime() <= $decoded['expires']
+		) {
+			return $decoded['data'];
+		}
+
+		return '';
+	}
+
+	/**
+	 * Set the request instance.
+	 */
+	public function setRequest(Request $request): static
+	{
+		$this->request = $request;
+
+		return $this;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function write($sessionId, $data): bool
+	{
+		$this->cookie->queue($sessionId, json_encode([
+			'data' => $data,
+			'expires' => $this->availableAt($this->minutes * 60),
+		]), $this->expireOnClose ? 0 : $this->minutes);
+
+		return true;
+	}
+}

--- a/src/Framework/Session/Store.php
+++ b/src/Framework/Session/Store.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MVPS\Lumis\Framework\Session;
 
 use Closure;

--- a/src/Framework/Session/Store.php
+++ b/src/Framework/Session/Store.php
@@ -1,8 +1,648 @@
 <?php
 namespace MVPS\Lumis\Framework\Session;
 
+use Closure;
+use Illuminate\Support\MessageBag;
+use Illuminate\Support\Traits\Macroable;
+use Illuminate\Support\ViewErrorBag;
+use MVPS\Lumis\Framework\Contracts\Session\ExistenceAware;
 use MVPS\Lumis\Framework\Contracts\Session\Session;
+use MVPS\Lumis\Framework\Http\Request;
+use MVPS\Lumis\Framework\Support\Arr;
+use MVPS\Lumis\Framework\Support\Str;
+use SessionHandlerInterface;
+use stdClass;
 
 class Store implements Session
 {
+	use Macroable;
+
+	/**
+	 * The session attributes.
+	 *
+	 * @var array
+	 */
+	protected array $attributes = [];
+
+	/**
+	 * The session handler implementation.
+	 *
+	 * @var \SessionHandlerInterface
+	 */
+	protected SessionHandlerInterface $handler;
+
+	/**
+	 * The session ID.
+	 *
+	 * @var string
+	 */
+	protected string $id;
+
+	/**
+	 * The session name.
+	 *
+	 * @var string
+	 */
+	protected string $name;
+
+	/**
+	 * The serialization format used for session data.
+	 *
+	 * @var string
+	 */
+	protected string $serialization = 'php';
+
+	/**
+	 * Indicates whether the session has been started.
+	 *
+	 * @var bool
+	 */
+	protected bool $started = false;
+
+	/**
+	 * Create a new session instance.
+	 */
+	public function __construct(
+		string $name,
+		SessionHandlerInterface $handler,
+		string|null $id = null,
+		string $serialization = 'php'
+	) {
+		$this->setId($id);
+
+		$this->name = $name;
+		$this->handler = $handler;
+		$this->serialization = $serialization;
+	}
+
+	/**
+	 * Age the flash data for the session.
+	 */
+	public function ageFlashData(): void
+	{
+		$this->forget($this->get('_flash.old', []));
+
+		$this->put('_flash.old', $this->get('_flash.new', []));
+
+		$this->put('_flash.new', []);
+	}
+
+	/**
+	 * Get all of the session data.
+	 */
+	public function all(): array
+	{
+		return $this->attributes;
+	}
+
+	/**
+	 * Decrement the value of an item in the session.
+	 */
+	public function decrement(string $key, int $amount = 1): int
+	{
+		return $this->increment($key, $amount * -1);
+	}
+
+	/**
+	 * Get all the session data except for a specified array of items.
+	 */
+	public function except(array $keys): array
+	{
+		return Arr::except($this->attributes, $keys);
+	}
+
+	/**
+	 * Checks if a key exists.
+	 */
+	public function exists(string|array $key): bool
+	{
+		$placeholder = new stdClass;
+
+		return ! collection(is_array($key) ? $key : func_get_args())
+			->contains(fn ($key) => $this->get($key, $placeholder) === $placeholder);
+	}
+
+	/**
+	 * Flash a key / value pair to the session.
+	 */
+	public function flash(string $key, mixed $value = true): void
+	{
+		$this->put($key, $value);
+
+		$this->push('_flash.new', $key);
+
+		$this->removeFromOldFlashData([$key]);
+	}
+
+	/**
+	 * Flash an input array to the session.
+	 */
+	public function flashInput(array $value): void
+	{
+		$this->flash('_old_input', $value);
+	}
+
+	/**
+	 * Remove all of the items from the session.
+	 */
+	public function flush(): void
+	{
+		$this->attributes = [];
+	}
+
+	/**
+	 * Remove one or many items from the session.
+	 */
+	public function forget(string|array $keys): void
+	{
+		Arr::forget($this->attributes, $keys);
+	}
+
+	/**
+	 * Get a new, random session ID.
+	 */
+	protected function generateSessionId(): string
+	{
+		return Str::random(40);
+	}
+
+	/**
+	 * Get an item from the session.
+	 */
+	public function get(string $key, mixed $default = null): mixed
+	{
+		Arr::get($this->attributes, $key, $default);
+	}
+
+	/**
+	 * Get the session handler instance.
+	 */
+	public function getHandler(): SessionHandlerInterface
+	{
+		return $this->handler;
+	}
+
+	/**
+	 * Get the current session ID.
+	 */
+	public function getId(): string
+	{
+		return $this->getId();
+	}
+
+	/**
+	 * Get the name of the session.
+	 */
+	public function getName(): string
+	{
+		return $this->name;
+	}
+
+	/**
+	 * Get the requested item from the flashed input array.
+	 */
+	public function getOldInput(string|null $key = null, mixed $default = null): mixed
+	{
+		return Arr::get($this->get('_old_input', []), $key, $default);
+	}
+
+	/**
+	 * Determine if the session handler needs a request.
+	 */
+	public function handlerNeedsRequest(): bool
+	{
+		return $this->handler instanceof CookieSessionHandler;
+	}
+
+	/**
+	 * Checks if a key is present and not null.
+	 */
+	public function has(string|array $key): bool
+	{
+		return ! collection(is_array($key) ? $key : func_get_args())
+			->contains(fn ($key) => is_null($this->get($key)));
+	}
+
+	/**
+	 * Determine if any of the given keys are present and not null.
+	 */
+	public function hasAny(string|array $key): bool
+	{
+		return collection(is_array($key) ? $key : func_get_args())
+			->filter(fn ($key) => ! is_null($this->get($key)))
+			->count() >= 1;
+	}
+
+	/**
+	 * Determine if the session contains old input.
+	 */
+	public function hasOldInput(string|null $key = null): bool
+	{
+		$old = $this->getOldInput($key);
+
+		return is_null($key) ? count($old) > 0 : ! is_null($old);
+	}
+
+	/**
+	 * Get the current session ID.
+	 */
+	public function id(): string
+	{
+		return $this->getId();
+	}
+
+	/**
+	 * Increment the value of an item in the session.
+	 */
+	public function increment(string $key, int $amount = 1): mixed
+	{
+		$value = $this->get($key, 0) + $amount;
+
+		$this->put($key, $value);
+
+		return $value;
+	}
+
+	/**
+	 * Flush the session data and regenerate the ID.
+	 */
+	public function invalidate(): bool
+	{
+		$this->flush();
+
+		return $this->migrate(true);
+	}
+
+	/**
+	 * Determine if the session has been started.
+	 */
+	public function isStarted(): bool
+	{
+		return $this->started;
+	}
+
+	/**
+	 * Determine if this is a valid session ID.
+	 */
+	public function isValidId(string|null $id): bool
+	{
+		return is_string($id) && ctype_alnum($id) && strlen($id) === 40;
+	}
+
+	/**
+	 * Reflash a subset of the current flash data.
+	 */
+	public function keep(mixed $keys = null): void
+	{
+		$keys = is_array($keys) ? $keys : func_get_args();
+
+		$this->mergeNewFlashes($keys);
+
+		$this->removeFromOldFlashData($keys);
+	}
+
+	/**
+	 * Load the session data from the handler.
+	 */
+	protected function loadSession(): void
+	{
+		$this->attributes = array_replace($this->attributes, $this->readFromHandler());
+
+		$this->marshalErrorBag();
+	}
+
+	/**
+	 * Marshal the ViewErrorBag when using JSON serialization for sessions.
+	 */
+	protected function marshalErrorBag(): void
+	{
+		if ($this->serialization !== 'json' || $this->missing('errors')) {
+			return;
+		}
+
+		$errorBag = new ViewErrorBag;
+
+		foreach ($this->get('errors') as $key => $value) {
+			$messageBag = new MessageBag($value['messages']);
+
+			$errorBag->put($key, $messageBag->setFormat($value['format']));
+		}
+
+		$this->put('errors', $errorBag);
+	}
+
+	/**
+	 * Merge new flash keys into the new flash array.
+	 */
+	protected function mergeNewFlashes(array $keys): void
+	{
+		$values = array_unique(array_merge($this->get('_flash.new', []), $keys));
+
+		$this->put('_flash.new', $values);
+	}
+
+	/**
+	 * Generate a new session ID for the session.
+	 */
+	public function migrate(bool $destroy = false): bool
+	{
+		if ($destroy) {
+			$this->handler->destroy($this->getId());
+		}
+
+		$this->setExists(false);
+
+		$this->setId($this->generateSessionId());
+
+		return true;
+	}
+
+	/**
+	 * Determine if the given key is missing from the session data.
+	 */
+	public function missing(string|array $key): bool
+	{
+		return ! $this->exists($key);
+	}
+
+	/**
+	 * Flash a key / value pair to the session for immediate use.
+	 */
+	public function now(string $key, mixed $value): void
+	{
+		$this->put($key, $value);
+
+		$this->push('_flash.old', $key);
+	}
+
+	/**
+	 * Get a subset of the session data.
+	 */
+	public function only(array $keys): array
+	{
+		return Arr::only($this->attributes, $keys);
+	}
+
+	/**
+	 * Specify that the user has confirmed their password.
+	 */
+	public function passwordConfirmed(): void
+	{
+		$this->put('auth.password_confirmed_at', time());
+	}
+
+	/**
+	 * Prepare the ViewErrorBag instance for JSON serialization.
+	 */
+	protected function prepareErrorBagForSerialization(): void
+	{
+		if ($this->serialization !== 'json' || $this->missing('errors')) {
+			return;
+		}
+
+		$errors = [];
+
+		foreach ($this->attributes['errors']->getBags() as $key => $value) {
+			$errors[$key] = [
+				'format' => $value->getFormat(),
+				'messages' => $value->getMessages(),
+			];
+		}
+
+		$this->attributes['errors'] = $errors;
+	}
+
+	/**
+	 * Prepare the serialized session data for storage.
+	 */
+	protected function prepareForStorage(string $data): string
+	{
+		return $data;
+	}
+
+	/**
+	 * Prepare the raw string data from the session for unserialization.
+	 */
+	protected function prepareForUnserialize(string $data): string
+	{
+		return $data;
+	}
+
+	/**
+	 * Get the previous URL from the session.
+	 */
+	public function previousUrl(): string|null
+	{
+		return $this->get('_previous.url');
+	}
+
+	/**
+	 * Get the value of a given key and then forget it.
+	 */
+	public function pull(string $key, mixed $default = null): mixed
+	{
+		return Arr::pull($this->attributes, $key, $default);
+	}
+
+	/**
+	 * Push a value onto a session array.
+	 */
+	public function push(string $key, mixed $value): void
+	{
+		$array = $this->get($key, []);
+
+		$array[] = $value;
+
+		$this->put($key, $array);
+	}
+
+	/**
+	 * Put a key / value pair or array of key / value pairs in the session.
+	 */
+	public function put(string|array $key, mixed $value = null): void
+	{
+		if (! is_array($key)) {
+			$key = [$key => $value];
+		}
+
+		foreach ($key as $arrayKey => $arrayValue) {
+			Arr::set($this->attributes, $arrayKey, $arrayValue);
+		}
+	}
+
+	/**
+	 * Read the session data from the handler.
+	 */
+	protected function readFromHandler(): array
+	{
+		$data = $this->handler->read($this->getId());
+
+		if ($data) {
+			$data = $this->serialization === 'json'
+				? json_decode($this->prepareForUnserialize($data), true)
+				: @unserialize($this->prepareForUnserialize($data));
+
+			if ($data !== false && is_array($data)) {
+				return $data;
+			}
+		}
+
+		return [];
+	}
+
+	/**
+	 * Reflash all of the session flash data.
+	 */
+	public function reflash(): void
+	{
+		$this->mergeNewFlashes($this->get('_flash.old', []));
+
+		$this->put('_flash.old', []);
+	}
+
+	/**
+	 * Generate a new session identifier.
+	 */
+	public function regenerate(bool $destroy = false): bool
+	{
+		return tap($this->migrate($destroy), fn () => $this->regenerateToken());
+	}
+
+	/**
+	 * Regenerate the CSRF token value.
+	 */
+	public function regenerateToken(): void
+	{
+		$this->put('_token', Str::random(40));
+	}
+
+	/**
+	 * Get an item from the session, or store the default value.
+	 */
+	public function remember(string $key, Closure $callback): mixed
+	{
+		$value = $this->get($key);
+
+		if (! is_null($value)) {
+			return $value;
+		}
+
+		return tap($callback(), fn ($value) => $this->put($key, $value));
+	}
+
+	/**
+	 * Remove an item from the session, returning its value.
+	 */
+	public function remove(string $key): mixed
+	{
+		return Arr::pull($this->attributes, $key);
+	}
+
+	/**
+	 * Remove the given keys from the old flash data.
+	 */
+	protected function removeFromOldFlashData(array $keys): void
+	{
+		$this->put('_flash.old', array_diff($this->get('_flash.old', []), $keys));
+	}
+
+	/**
+	 * Replace the given session attributes entirely.
+	 */
+	public function replace(array $attributes): void
+	{
+		$this->put($attributes);
+	}
+
+	/**
+	 * Save the session data to storage.
+	 */
+	public function save(): void
+	{
+		$this->ageFlashData();
+
+		$this->prepareErrorBagForSerialization();
+
+		$this->handler->write($this->getId(), $this->prepareForStorage(
+			$this->serialization === 'json'
+				? json_encode($this->attributes)
+				: serialize($this->attributes)
+		));
+
+		$this->started = false;
+	}
+
+	/**
+	 * Set the existence of the session on the handler if applicable.
+	 */
+	public function setExists(bool $value): void
+	{
+		if ($this->handler instanceof ExistenceAware) {
+			$this->handler->setExists($value);
+		}
+	}
+
+	/**
+	 * Set the underlying session handler implementation.
+	 */
+	public function setHandler(SessionHandlerInterface $handler): SessionHandlerInterface
+	{
+		return $this->handler = $handler;
+	}
+
+	/**
+	 * Set the session ID.
+	 */
+	public function setId(string $id): void
+	{
+		$this->id = $this->isValidId($id) ? $id : $this->generateSessionId();
+	}
+
+	/**
+	 * Set the name of the session.
+	 */
+	public function setName(string $name): void
+	{
+		$this->name = $name;
+	}
+
+	/**
+	 * Set the "previous" URL in the session.
+	 */
+	public function setPreviousUrl(string $url): void
+	{
+		$this->put('_previous.url', $url);
+	}
+
+	/**
+	 * Set the request on the handler instance.
+	 */
+	public function setRequestOnHandler(Request $request): void
+	{
+		if ($this->handlerNeedsRequest()) {
+			$this->handler->setRequest($request);
+		}
+	}
+
+	/**
+	 * Start the session, reading the data from a handler.
+	 */
+	public function start(): bool
+	{
+		$this->loadSession();
+
+		if (! $this->has('_token')) {
+			$this->regenerateToken();
+		}
+
+		return $this->started = true;
+	}
+
+	/**
+	 * Get the CSRF token value.
+	 */
+	public function token(): string
+	{
+		return $this->get('_token');
+	}
 }

--- a/src/Framework/Session/Store.php
+++ b/src/Framework/Session/Store.php
@@ -1,0 +1,8 @@
+<?php
+namespace MVPS\Lumis\Framework\Session;
+
+use MVPS\Lumis\Framework\Contracts\Session\Session;
+
+class Store implements Session
+{
+}

--- a/src/Framework/config/session.php
+++ b/src/Framework/config/session.php
@@ -1,0 +1,210 @@
+<?php
+
+use MVPS\Lumis\Framework\Support\Str;
+
+return [
+	/*
+	|--------------------------------------------------------------------------
+	| Default Session Driver
+	|--------------------------------------------------------------------------
+	|
+	| Configure the default session storage driver. Lumis supports multiple
+	| options for persisting session data. The 'database' driver is set as
+	| the default.
+	|
+	| Supported options: "file", "cookie", "database", "array"
+	|
+	*/
+	'driver' => env('SESSION_DRIVER', 'database'),
+
+	/*
+	|--------------------------------------------------------------------------
+	| Session Lifetime
+	|--------------------------------------------------------------------------
+	|
+	| Configure the session lifetime and expiration behavior.
+	|
+	| The `lifetime` option specifies the number of minutes a session remains
+	| active after the last user activity. The `expire_on_close` option
+	| determines if the session expires when the browser is closed, overriding
+	| the `lifetime` setting.
+	|
+	*/
+	'lifetime' => env('SESSION_LIFETIME', 120),
+
+	'expire_on_close' => env('SESSION_EXPIRE_ON_CLOSE', false),
+
+	/*
+	|--------------------------------------------------------------------------
+	| Session Encryption
+	|--------------------------------------------------------------------------
+	|
+	| Enable automatic encryption of session data before storage. This
+	| provides an added layer of security for sensitive session information.
+	|
+	*/
+	'encrypt' => env('SESSION_ENCRYPT', false),
+
+	/*
+	|--------------------------------------------------------------------------
+	| Session File Storage Path
+	|--------------------------------------------------------------------------
+	|
+	| Configure the directory where session files are stored when using the
+	| "file" driver. This path defines the default location for session data.
+	|
+	*/
+	'files' => storage_path('framework/sessions'),
+
+	/*
+	|--------------------------------------------------------------------------
+	| Session Database Connection
+	|--------------------------------------------------------------------------
+	|
+	| Configure the database connection used for storing session data when
+	| using the "database" session drivers. This value should correspond to
+	| a connection defined in your database configuration.
+	|
+	*/
+	'connection' => env('SESSION_CONNECTION'),
+
+	/*
+	|--------------------------------------------------------------------------
+	| Session Database Table
+	|--------------------------------------------------------------------------
+	|
+	| Configure the database table used to store session data when using the
+	| "database" session driver. The default table name is "sessions".
+	|
+	*/
+	'table' => env('SESSION_TABLE', 'sessions'),
+
+	/*
+	|--------------------------------------------------------------------------
+	| Session Sweeping Lottery
+	|--------------------------------------------------------------------------
+	|
+	| Configure the probability of session garbage collection on each request.
+	|
+	| The first value represents the number of successful attempts required.
+	| The second value represents the total number of attempts.
+	|
+	| For example, [2, 100] means there is a 2% chance of garbage collection
+	| on each request.
+	|
+	*/
+	'lottery' => [2, 100],
+
+	/*
+	|--------------------------------------------------------------------------
+	| Session Cookie Name
+	|--------------------------------------------------------------------------
+	|
+	| Configure the name of the session cookie used for storing session data.
+	| The default value is usually sufficient for most applications.
+	|
+	*/
+	'cookie' => env(
+		'SESSION_COOKIE',
+		Str::slug(env('APP_NAME', 'Lumis'), '_') . '_session'
+	),
+
+	/*
+	|--------------------------------------------------------------------------
+	| Session Cookie Path
+	|--------------------------------------------------------------------------
+	|
+	| Configure the path where the session cookie is accessible. This value
+	| typically matches your application's root path.
+	|
+	*/
+	'path' => env('SESSION_PATH', '/'),
+
+	/*
+	|--------------------------------------------------------------------------
+	| Session Cookie Domain
+	|--------------------------------------------------------------------------
+	|
+	| Configure the domain for the session cookie. This value determines the
+	| domains and subdomains where the cookie is accessible. The default
+	| value allows access from the root domain and all subdomains.
+	|
+	*/
+	'domain' => env('SESSION_DOMAIN', ''),
+
+	/*
+	|--------------------------------------------------------------------------
+	| HTTPS Only Cookies
+	|--------------------------------------------------------------------------
+	|
+	| Require HTTPS for session cookie transmission.
+	|
+	| When enabled, the session cookie is only sent over secure HTTPS
+	| connections, preventing transmission over insecure HTTP connections.
+	|
+	*/
+	'secure' => env('SESSION_SECURE_COOKIE'),
+
+	/*
+	|--------------------------------------------------------------------------
+	| HTTP Only Cookies
+	|--------------------------------------------------------------------------
+	|
+	| When enabled, the session cookie will only be accessible through the
+	| HTTP protocol, preventing client-side JavaScript from reading its value.
+	| This enhances security by mitigating potential cross-site scripting
+	| (XSS) attacks.
+	|
+	*/
+	'http_only' => env('SESSION_HTTP_ONLY', true),
+
+	/*
+	|--------------------------------------------------------------------------
+	| SameSite Cookies
+	|--------------------------------------------------------------------------
+	|
+	| This option configures the "SameSite" attribute of cookies used for
+	| session management. The SameSite attribute helps mitigate Cross-Site
+	| Request Forgery (CSRF) attacks by restricting when browser can send
+	| cookies in cross-site requests.
+	|
+	| By default, this value is set to "lax". This permits cookies to be sent
+	| in same-site and cross-site requests initiated with navigation methods
+	| (like links, forms) but not with cross-site requests initiated through
+	| JavaScript (e.g., XMLHttpRequest).
+	|
+	| You can choose a stricter option for enhanced security:
+	|
+	| - "strict": Prevents sending cookies in any cross-site requests,
+	|             including navigation methods.
+	| - "none": Allows sending cookies only in secure HTTPS requests and
+	|           requires the "Secure" attribute to be set on the cookie as
+	|           well. This option should be used with caution due to
+	|           compatibility issues with older browsers.
+	|
+	| Disabling SameSite by setting it to `null` is generally not recommended
+	| for security reasons.
+	|
+	| See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value
+	|
+	| Supported options: "lax", "strict", "none", null
+	|
+	*/
+	'same_site' => env('SESSION_SAME_SITE', 'lax'),
+
+	/*
+	|--------------------------------------------------------------------------
+	| Partitioned Cookies
+	|--------------------------------------------------------------------------
+	|
+	| Enable partitioned cookies for cross-site contexts. This requires the
+	| cookie to be marked as secure and have the SameSite attribute set to
+	| "none".
+	|
+	| Note: Partitioned cookies are a security feature designed to prevent
+	| cross-site request forgery (CSRF) attacks. Use with caution and ensure
+	| proper configuration.
+	|
+	*/
+	'partitioned' => env('SESSION_PARTITIONED_COOKIE', false),
+];

--- a/src/Framework/helpers.php
+++ b/src/Framework/helpers.php
@@ -451,6 +451,16 @@ if (! function_exists('task_path')) {
 	}
 }
 
+if (! function_exists('to_route')) {
+	/**
+	 * Create a new redirect response to a named route.
+	 */
+	function to_route(string $route, mixed $parameters = [], int $status = 302, array $headers = []): RedirectResponse
+	{
+		return redirect()->route($route, $parameters, $status, $headers);
+	}
+}
+
 if (! function_exists('url')) {
 	/**
 	 * Generate a url for the application.

--- a/src/Framework/helpers.php
+++ b/src/Framework/helpers.php
@@ -6,6 +6,7 @@ use Faker\Generator as FakerGenerator;
 use MVPS\Lumis\Framework\Container\Container;
 use MVPS\Lumis\Framework\Contracts\Exceptions\ExceptionHandler;
 use MVPS\Lumis\Framework\Contracts\Http\Responsable;
+use MVPS\Lumis\Framework\Contracts\Routing\ResponseFactory;
 use MVPS\Lumis\Framework\Contracts\Routing\UrlGenerator;
 use MVPS\Lumis\Framework\Contracts\Support\Arrayable;
 use MVPS\Lumis\Framework\Contracts\View\Factory as ViewFactory;
@@ -13,7 +14,6 @@ use MVPS\Lumis\Framework\Contracts\View\View;
 use MVPS\Lumis\Framework\Http\Exceptions\HttpResponseException;
 use MVPS\Lumis\Framework\Http\Request;
 use MVPS\Lumis\Framework\Http\Response;
-use MVPS\Lumis\Framework\Routing\ResponseFactory;
 use MVPS\Lumis\Framework\Support\HtmlString;
 use MVPS\Lumis\Framework\Support\Str;
 

--- a/src/Framework/helpers.php
+++ b/src/Framework/helpers.php
@@ -12,8 +12,10 @@ use MVPS\Lumis\Framework\Contracts\Support\Arrayable;
 use MVPS\Lumis\Framework\Contracts\View\Factory as ViewFactory;
 use MVPS\Lumis\Framework\Contracts\View\View;
 use MVPS\Lumis\Framework\Http\Exceptions\HttpResponseException;
+use MVPS\Lumis\Framework\Http\RedirectResponse;
 use MVPS\Lumis\Framework\Http\Request;
 use MVPS\Lumis\Framework\Http\Response;
+use MVPS\Lumis\Framework\Routing\Redirector;
 use MVPS\Lumis\Framework\Support\HtmlString;
 use MVPS\Lumis\Framework\Support\Str;
 
@@ -70,6 +72,16 @@ if (! function_exists('app_path')) {
 	function app_path(string $path = ''): string
 	{
 		return app()->path($path);
+	}
+}
+
+if (! function_exists('back')) {
+	/**
+	 * Create a new redirect response to the previous location.
+	 */
+	function back(int $status = 302, array $headers = [], mixed $fallback = false): RedirectResponse
+	{
+		return app('redirect')->back($status, $headers, $fallback);
 	}
 }
 
@@ -244,6 +256,27 @@ if (! function_exists('public_path')) {
 	function public_path(string $path = ''): string
 	{
 		return app()->publicPath($path);
+	}
+}
+
+if (! function_exists('redirect')) {
+	/**
+	 * Creates a redirect response or retrieves the redirector instance.
+	 *
+	 * If a target URL is provided, a RedirectResponse instance is returned.
+	 * Otherwise, the redirector instance is returned for building redirects.
+	 */
+	function redirect(
+		string|null $to = null,
+		int $status = 302,
+		array $headers = [],
+		bool|null $secure = null
+	): Redirector|RedirectResponse {
+		if (is_null($to)) {
+			return app('redirect');
+		}
+
+		return app('redirect')->to($to, $status, $headers, $secure);
 	}
 }
 


### PR DESCRIPTION
## Change Log

### New Features & Enhancements

- Updated `MVPS\Lumis\Framework\Http\Request`:
	- Added methods:
		- `isMethodCacheable`
- Updated `MVPS\Lumis\Framework\Contracts\Routing\ResponseFactory`:
	- Added methods:
		- `download`
		- `file`
		- `json`
		- `jsonp`
		- `redirectGuest`
		- `redirectTo`
		- `redirectToAction`
		- `redirectToIntended`
		- `redirectToRoute`
		- `stream`
		- `streamDownload`
- Updated `MVPS\Lumis\Framework\Http\ResponseFactory`
	- Moved to `MVPS\Lumis\Framework\Routing` namespace
	- Removed extension of `pdeans\Http\Factories\ResponseFactory` class
	- Removed `MVPS\Lumis\Framework\Http\Traits\InteractsWithContent` and `MVPS\Lumis\Framework\Http\Traits\ResponseTrait` trait usage
	- Added `Illuminate\Support\Traits\Macroable` trait usage
	- Added methods:
		- `download`
		- `fallbackName`
		- `file`
		- `json`
		- `jsonp`
		- `redirectGuest`
		- `redirectTo`
		- `redirectToAction`
		- `redirectToIntended`
		- `redirectToRoute`
		- `stream`
		- `streamDownload`
- Removed `MVPS\Lumis\Framework\Http\Traits\InteractsWithContent`
- Updated `MVPS\Lumis\Framework\Http\Request`:
	- Removed `MVPS\Lumis\Framework\Http\Traits\InteractsWithContent` trait usage
	- Added properties:
		- `format`
	- Added methods:
		- `getETags`
		- `getRequestFormat`
		- `isMethodCacheable`
		- `isMethodSafe`
		- `setRequestFormat`
- Updated `MVPS\Lumis\Framework\Http\Response`:
	- Added `Illuminate\Support\Traits\Macroable` trait usage
	- Added `MVPS\Lumis\Framework\Http\Traits\StatusCodes` trait usage
	- Added properties:
		- `HTTP_RESPONSE_CACHE_CONTROL_DIRECTIVES` (constant)
		- `content`
		- `sentHeaders`
	- Added methods:
		- `getAge`
		- `getContent`
		- `getDate`
		- `getEtag`
		- `getExpires`
		- `getLastModified`
		- `getMaxAge`
		- `getTtl`
		- `isCacheable`
		- `isClientError`
		- `isEmpty`
		- `isForbidden`
		- `isFresh`
		- `isInformational`
		- `isInvalid`
		- `isNotFound`
		- `isNotModified`
		- `isOk`
		- `isRedirect`
		- `isRedirection`
		- `isServerError`
		- `isSuccessful`
		- `isValidateable`
		- `morphToJson`
		- `setCache`
		- `setContent`
		- `setEtag`
		- `setLastModified`
		- `setMaxAge`
		- `setNotModified`
		- `setPrivate`
		- `setPublic`
		- `setSharedMaxAge`
		- `setStaleIfError`
		- `setStaleWhileRevalidate`
		- `shouldBeJson`
		- `withNotModified`
		- `withStatus`
	- Removed methods:
		- `withHeaders`
- Updated `MVPS\Lumis\Framework\Exceptions\Handler`:
	- Removed `responseFactory` property
	- Replaced response factory `make` references with `MVPS\Lumis\Framework\Http\Response` class instantiation
- Added `MVPS\Lumis\Framework\Http\Traits\InteractsWithHeaders`
- Added `MVPS\Lumis\Framework\Http\Traits\StatusCodes`
- Added `MVPS\Lumis\Framework\Http\Middleware\SetCacheHeaders`
- Added `MVPS\Lumis\Framework\Http\Middleware\CheckResponseForModifications`
- Added `MVPS\Lumis\Framework\Http\BinaryFileResponse`
- Added `MVPS\Lumis\Framework\Http\JsonResponse`
- Added `MVPS\Lumis\Framework\Http\File`
- Added `MVPS\Lumis\Framework\Http\RedirectResponse`
- Added `MVPS\Lumis\Framework\Http\StreamedResponse`
- Added `MVPS\Lumis\Framework\Routing\Exceptions\StreamedResponseException`
- Added `MVPS\Lumis\Framework\Contracts\Session\ExistenceAware`
- Added `MVPS\Lumis\Framework\Contracts\Session\Session`
- Added `MVPS\Lumis\Framework\Session\CookieSessionHandler`
- Added `MVPS\Lumis\Framework\Session\Store`
- Added `MVPS\Lumis\Framework\Contracts\Cookie\Factory`
- Added `MVPS\Lumis\Framework\Contracts\Cookie\QueueingFactory`
- Added `MVPS\Lumis\Framework\Cookie\CookieJar`
- Added `MVPS\Lumis\Framework\Cookie\CookieServiceProvider`
- Added `MVPS\Lumis\Framework\Cookie\CookieServiceProvider` to default providers list in `MVPS\Lumis\Framework\Providers\DefaultProviders`
- Added `MVPS\Lumis\Framework\Routing\Redirector`
- Added `previous` method to `MVPS\Lumis\Framework\Contracts\Routing\UrlGenerator`
- Added `registerRedirector` method to `MVPS\Lumis\Framework\Routing\RoutingServiceProvider`
- Added `MVPS\Lumis\Framework\Routing\RedirectController`
- Updated `MVPS\Lumis\Framework\Routing\ResponseFactory`:
	- Added `redirector` property
	- Updated `__construct` to accept `MVPS\Lumis\Framework\Routing\Redirector` instance parameter to define `redirector` property
	- Added methods:
		- `redirectGuest`
		- `redirectTo`
		- `redirectToAction`
		- `redirectToIntended`
		- `redirectToRoute`
- Updated `MVPS\Lumis\Framework\Routing\UrlGenerator`:
	- Added methods:
		- `getPreviousUrlFromSession`
		- `getSession`
		- `previous`
		- `setSessionResolver`
- Updated `MVPS\Lumis\Framework\Routing\Router`:
	- Added methods:
		- `permanentRedirect`
		- `redirect`
- Updated `MVPS\Lumis\Framework\Application`:
	- Added core container aliases:
		- `cookie`
		- `redirect`
		- `session.store`
- Added helper functions:
	- `back`
	- `redirect`
	- `to_route`